### PR TITLE
Fix error with fit="true" and markers is undefined

### DIFF
--- a/src/angular-google-maps.js
+++ b/src/angular-google-maps.js
@@ -503,7 +503,7 @@
             
             // Fit map when there are more than one marker. 
             // This will change the map center coordinates
-            if (attrs.fit == "true" && newValue.length > 1) {
+            if (attrs.fit == "true" && newValue && newValue.length > 1) {
               _m.fit();
             }
           });


### PR DESCRIPTION
When fit is set and markers is not, this line raises "TypeError: Cannot read property 'length' of undefined"
