### PR TITLE
angular-mocks must be declared as a development dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,9 @@
   "name": "angular-google-maps",
   "version": "1.0.2",
   "dependencies": {
-    "angular": "~1.2.2",
+    "angular": "~1.2.2"
+  },
+  "devDependencies": {
     "angular-mocks": "~1.2.2"
   }
 }


### PR DESCRIPTION
In `bower.json`, `angular-mocks` is declared as a runtime dependency (while it is a development dependency). In addition to not complying with Bower standards, this declaration adds resolution conflicts. For instance, I have a project called `XXX` that uses `angular` 1.2.7 and `angular-google-maps` 1.0.2. It should not raise any issue because `angular-google-maps` expects `angular` ~1.2.2 (which resolves to my `angular` 1.2.7). But `angular-mocks` ~1.2.2. refers to `angular-mocks` 1.2.8 (which expects `angular` 1.2.8-build.2094+sha.b6c42d5). And consequently, it produces the following output during `bower install`:

```
Unable to find a suitable version for angular, please choose one:
    1) angular#1.2.7 which resolved to 1.2.7 and has angular-mocks#1.2.7, XXX as dependants
    2) angular#~1.2.2 which resolved to 1.2.8-build.2094+sha.b6c42d5 and has angular-google-maps#1.0.2 as dependants
    3) angular#1.2.8-build.2094+sha.b6c42d5 which resolved to 1.2.8-build.2094+sha.b6c42d5 and has angular-mocks#1.2.8-build.2094+sha.b6c42d5 as dependants
```

Of course, I could add a `resolution` entry to my `bower.json`. But I think it is better to fix the problem at its root.
