### PR TITLE
Add missing bower.json property of "main"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-google-maps",
   "version": "1.0.3",
+  "main": "./dist/angular-google-maps.js",
   "dependencies": {
     "angular": "~1.2.2"
   },


### PR DESCRIPTION
If we don't have the primary endpoints of this package then "grunt-bower-install" couldn't work.
