### PR TITLE
Fix script command in Travis CI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
     - "0.11"
     - "0.10"
     - "0.8"
-script: grunt test --force
+script: grunt
 branches:
   only:
     - master


### PR DESCRIPTION
`travis.yml` uses a Grunt task that was never implemented and, because of the option `--force`, the tests fail silently on Travis CI. Since I noticed the default Grunt task prepares the environment and runs the test suite, I updated the script command to use it.
