### PR TITLE
Add underscore to Bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "version": "1.0.4",
   "main": "./dist/angular-google-maps.js",
   "dependencies": {
-    "angular": "~1.2.2"
+    "angular": "~1.2.2",
+    "underscore": "~1.5.2"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.2"


### PR DESCRIPTION
Since 18aeb777ebe79ee6db5dfdaf0981ca734c329180, `angular-google-maps` requires `underscore`. However, this library has not been added to the dependency list in `bower.json`. As a result, any application that uses `angular-google-maps` without loading `underscore` first will crash.

Please note that I only added the missing entry in `bower.json`.

Maybe it would be a good thing to run `bower install` (manually or via https://github.com/stephenplusplus/grunt-bower-install) before running tests and to use these librairies instead of those versioned.
