### PR TITLE
Run `bower install` before running tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
     - "0.11"
     - "0.10"
     - "0.8"
+before_script: PATH="$(npm bin):$PATH" bower install
 script: grunt
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AngularJS directives for Google Maps",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nlaplante/angular-google-maps.git"  
+    "url": "https://github.com/nlaplante/angular-google-maps.git"
   },
   "scripts": {
     "build": "grunt",
@@ -31,9 +31,10 @@
     "grunt-open": "~0.2.2",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-coffee": "~0.7.0",
-    "grunt-contrib-jasmine":"~0.5.2",
-    "grunt-template-jasmine-requirejs":"~0.1.8",
-    "grunt-template-jasmine-istanbul":"~0.2.5"
+    "grunt-contrib-jasmine": "~0.5.2",
+    "grunt-template-jasmine-requirejs": "~0.1.8",
+    "grunt-template-jasmine-istanbul": "~0.2.5",
+    "bower": "~1.2.8"
   },
   "dependencies": {
     "grunt-cli": "~0.1.11",


### PR DESCRIPTION
Since 7ad66fbaefee5491eed192773802d6ff7fb9bb07, you need to run `bower install` on Travis CI.

As a result:
- `bower` has been added to the `devDependency` list in `package.json` ;
- `bower install` has been added as a `before_script` in `travis.yml`.
