### PR TITLE
Chore: show documentation is current in Readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,11 +32,10 @@ grunt example
 
 and open your browser on `http://localhost:3000/example.html`.
 
-The various directives are documented at [official site](http://nlaplante.github.io/angular-google-maps). Please note these
-are OUTDATED and updates will come as soon as possible.
+### Documentation
+The various directives are documented at [official site](http://angular-google-maps.org).
 
 ### Contributing
-
 Pull requests more than welcome! If you're adding new features, it would be appreciated if you would provide some docs about the feature. This can be done either by adding a card to our [Trello board](https://trello.com/b/WwTRrkfh/angular-google-maps), forking the website branch and issuing a PR with the updated documentation page, or by opening an issue for us to add the documentation to the site.
 
 [Branching Model w Git Flow](http://nvie.com/posts/a-successful-git-branching-model/)


### PR DESCRIPTION
Hi.  
It looks like the documentation is now current.  
Instead of asking I just made this pull request
 :kiss:,
aaron 
