### PR TITLE
(bug) Fix parent destroy listener 'this' binding

### DIFF
--- a/src/coffee/directives/api/models/parent/layer-parent-model.coffee
+++ b/src/coffee/directives/api/models/parent/layer-parent-model.coffee
@@ -26,7 +26,7 @@
                         @layer = null
                         @createGoogleLayer()
                 , true)
-                @scope.$on "$destroy", ->
+                @scope.$on "$destroy", =>
                     @layer.setMap null
 
         createGoogleLayer: ()=>


### PR DESCRIPTION
The $destroy listener used -> which did not correctly bind @layer, 'this' came into the callback function as the window object. Therefore, an undefined reference was being thrown. Change -> to => so coffee will bind to _this.layer instead.
