### PR TITLE
Remove Polygon event listeners

### DIFF
--- a/src/coffee/directives/polygon.coffee
+++ b/src/coffee/directives/polygon.coffee
@@ -179,11 +179,11 @@ angular.module("google-maps").directive "polygon", ["$log", "$timeout", ($log, $
             # Remove polyline on scope $destroy
             scope.$on "$destroy", ->
                 polyline.setMap null
-                pathSetAtListener()
+                google.maps.event.removeListener(pathSetAtListener)
                 pathSetAtListener = null
-                pathInsertAtListener()
+                google.maps.event.removeListener(pathInsertAtListener)
                 pathInsertAtListener = null
-                pathRemoveAtListener()
+                google.maps.event.removeListener(pathRemoveAtListener)
                 pathRemoveAtListener = null
 
 


### PR DESCRIPTION
The correct way to get rid of google maps' event listeners is passing them to `google.maps.event.removeListener`
