### PR TITLE
'icon' description in <markers> directive fixed

### DIFF
--- a/app/views/directive/markers.html
+++ b/app/views/directive/markers.html
@@ -128,7 +128,7 @@ $scope.clickEventsObject =
     <tr>
         <td>icon</td>
         <td><span class="label label-info">string</span></td>
-        <td>url to the icon image to use for each marker</td>
+        <td>The name of the property of the model in the models array containing the URL to the icon image to use for each marker</td>
     </tr>
     <tr>
         <td>click</td>


### PR DESCRIPTION
It's not the URL of the icon, it's the name of the model's property.
