### PR TITLE
- When adding the property fit="true" to a polygon tag, the google maps ...

### DIFF
--- a/src/coffee/directives/polygon.coffee
+++ b/src/coffee/directives/polygon.coffee
@@ -96,8 +96,15 @@ angular.module("google-maps")
                 opts.editable = false if opts.static
                 opts
             map = mapCtrl.getMap()
-            polygon = new google.maps.Polygon(buildOpts(GmapUtil.convertPathPoints(scope.path)))
+            pathPoints = GmapUtil.convertPathPoints(scope.path)
+            polygon = new google.maps.Polygon(buildOpts(pathPoints))
             GmapUtil.extendMapBounds map, pathPoints  if isTrue(attrs.fit)
+
+            if !scope.static and angular.isDefined(scope.path)
+                scope.$watch "path", (newValue, oldValue) ->
+                    pathPoints = GmapUtil.convertPathPoints(newValue)
+                    GmapUtil.extendMapBounds map, pathPoints  if isTrue(attrs.fit)
+            
             if !scope.static and angular.isDefined(scope.editable)
                 scope.$watch "editable", (newValue, oldValue) ->
                     polygon.setEditable newValue if newValue != oldValue


### PR DESCRIPTION
...will now fit to bounds correctly and not give you a "pathPoints not defined" error. (issue 472)

See issue at https://github.com/nlaplante/angular-google-maps/issues/472
