### PR TITLE
Add first round of granular examples to the website.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "0.8"
+    - "0.10"
 before_script: 
     - npm install -g bower
     - bower cache clean

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,8 @@ var mountFolder = function (connect, dir) {
 module.exports = function (grunt) {
   require('load-grunt-tasks')(grunt);
   require('time-grunt')(grunt);
+  
+  grunt.loadNpmTasks("grunt-git-log-json");
 
   // configurable paths
   var yeomanConfig = {
@@ -249,7 +251,8 @@ module.exports = function (grunt) {
             '.htaccess',
             'bower_components/**/*',
             'images/{,*/}*.{gif,webp}',
-            'styles/fonts/*'
+            'styles/fonts/*',
+            'views/examples/{,*/}*.*'
           ]
         }, {
           expand: true,
@@ -318,6 +321,12 @@ module.exports = function (grunt) {
           ]
         }
       }
+    },
+    git_log_json: {
+        options: {
+           shortHash: true,
+           dest: '<%= yeoman.app %>/changelog.json'
+        }
     }
   });
 
@@ -350,13 +359,15 @@ module.exports = function (grunt) {
     'concurrent:dist',
     'autoprefixer',
     'concat',
+    'git_log_json',
     'copy:dist',
     'cdnify',
     'ngmin',
     'cssmin',
     'uglify',
     'rev',
-    'usemin'
+    'usemin',
+    'git_log_json'
   ]);
 
   grunt.registerTask('default', [

--- a/app/headlines.json
+++ b/app/headlines.json
@@ -1,47 +1,64 @@
 {
-	"items": [
-	  {
-	     "title": "GeoJSON support",
-	     "date": "Mar. 22 2014",
-	     "content": "<p>The google-maps, circle, marker, markers, polygon, polyline, window & windows directive now support <a href='http://geojson.org/geojson-spec.html'>GeoJSON</a> coordindates, in addition to the standard latitude/longitude object parameters.  See <a href='/api'>the docs</a>!</p>"
-	  },
-	  {
-			"title": "Layer directive hotfix",
-			"date": "Feb. 10 2014",
-			"content": "<p>There was a bug in the layer directive which prevented passing options to the underlying layer. This has been fixed in version 1.0.10.</p><p>Thanks <a href='https://github.com/netmonster01' rel='external'>netmonster01</a> for reporting this!</p>"
-		}, {
-			"title": "New directive: rectangle",
-			"date": "Feb. 8 2014",
-			"content": "<p>Thanks to <a href='https://github.com/ChenTsuLin' rel='external'>ChenTsuLin</a>, we now have a rectangle directive. See <a href='/api#rectangle'>the docs</a>!</p>"
-		}, {
-			"title": "New website is finally online!",
-			"date": "Jan. 11 2014",
-			"content": "<p>We are pleased to announce that our new website is finally online over at http://angular-google-maps.org ! The demo is still under development and the docs are almost 100% finished. Please leave your feedback over at our <a href='https://plus.google.com/communities/101653511105172739950?utm_source=websiten&utm_medium=link' rel='external'>Google+ community</a> or file issues in our <a href='https://github.com/nlaplante/angular-google-maps/issues?state=open' rel='external'>issue tracker</a>.</p>"
-		},
-		{
-		 	"title": "Official Google+ community",
-		 	"date": "Dec. 17 2013",
-		 	"content": "<p>We now have our <a href='https://plus.google.com/communities/101653511105172739950' rel='external'>Google+ community</a>! Please join to share your experience with this library, tips and tricks and to receive official announcements.</p>"
-	        }, {
-			"title": "angular-google-maps 1.0.0 released!",
-			"date": "Nov. 27 2013",
-			"content": "<p>We are proud to announce that the first stable version of angular-google-maps has just be released!</p><p>The r1-dev branch has been merged back in master, and the old library is available in the legacy branch.</p>"
-		}, {
-			"title": "New website in the works",
-			"date": "Oct. 20 2013",
-			"content": "<p>A brand new website for angular-google-maps is in the works. It will be more complete than the actual one and actually provide a complete API documentation as well as a quickstart guide. It will replace the existing site as soon as the next library version is released.</p>"
-		}, {
-			"title": "master branch moving to legacy soon",
-			"date": "Oct. 8 2013",
-			"content": "<p>For users of the current <code>master</code> branch, please note that it will renamed to <code>legacy</code> as soon as <code>r1-dev</code> has been completed and tagged as a release. The angular-google-maps website will reflect the api of the new <code>master</code> branch.</p>"
-		}, {
-			"title": "AngularJS 1.2 support",
-			"date": "Sept. 21 2013",
-			"content": "<p>angular-google-maps supports AngularJS 1.2 in the <code>r1-dev</code> branch, which will become the <code>master</code> branch once released.</p>"
-		}, {
-			"title": "Code overhaul",
-			"date": "May 11 2013",
-			"content": "<p>A new branch has been created which will be used to rewrite most of angular-google-maps and split it in separate directives. This will allow a simplified development process and easier overall integration in your projects.</p><p>Check out the <a href='https://github.com/nlaplante/angular-google-maps/tree/r1-dev'>r1-dev</a> branch now!"
-		}
-	]
+  "items": [
+    {
+      "title": "1.1.0 Documentation Added",
+      "date": "May 17 2014",
+      "content": "<p>Many undocumented directives/features are now.. documented :). Documentation now reflects 1.1.0 (was develop branch)!!</p>"
+    },
+    {
+      "title": "New change log page",
+      "date": "May 4 2014",
+      "content": "<p>We now have a brand new page hosting the changelog of angular-google-maps! It's <a href='/changelog'>over here</a>!"
+    },
+    {
+      "title": "GeoJSON support",
+      "date": "Mar. 22 2014",
+      "content": "<p>The google-maps, circle, marker, markers, polygon, polyline, window & windows directive now support <a href='http://geojson.org/geojson-spec.html'>GeoJSON</a> coordindates, in addition to the standard latitude/longitude object parameters.  See <a href='/api'>the docs</a>!</p>"
+    },
+    {
+      "title": "Layer directive hotfix",
+      "date": "Feb. 10 2014",
+      "content": "<p>There was a bug in the layer directive which prevented passing options to the underlying layer. This has been fixed in version 1.0.10.</p><p>Thanks <a href='https://github.com/netmonster01' rel='external'>netmonster01</a> for reporting this!</p>"
+    },
+    {
+      "title": "New directive: rectangle",
+      "date": "Feb. 8 2014",
+      "content": "<p>Thanks to <a href='https://github.com/ChenTsuLin' rel='external'>ChenTsuLin</a>, we now have a rectangle directive. See <a href='/api#rectangle'>the docs</a>!</p>"
+    },
+    {
+      "title": "New website is finally online!",
+      "date": "Jan. 11 2014",
+      "content": "<p>We are pleased to announce that our new website is finally online over at http://angular-google-maps.org ! The demo is still under development and the docs are almost 100% finished. Please leave your feedback over at our <a href='https://plus.google.com/communities/101653511105172739950?utm_source=websiten&utm_medium=link' rel='external'>Google+ community</a> or file issues in our <a href='https://github.com/nlaplante/angular-google-maps/issues?state=open' rel='external'>issue tracker</a>.</p>"
+    },
+    {
+      "title": "Official Google+ community",
+      "date": "Dec. 17 2013",
+      "content": "<p>We now have our <a href='https://plus.google.com/communities/101653511105172739950' rel='external'>Google+ community</a>! Please join to share your experience with this library, tips and tricks and to receive official announcements.</p>"
+    },
+    {
+      "title": "angular-google-maps 1.0.0 released!",
+      "date": "Nov. 27 2013",
+      "content": "<p>We are proud to announce that the first stable version of angular-google-maps has just be released!</p><p>The r1-dev branch has been merged back in master, and the old library is available in the legacy branch.</p>"
+    },
+    {
+      "title": "New website in the works",
+      "date": "Oct. 20 2013",
+      "content": "<p>A brand new website for angular-google-maps is in the works. It will be more complete than the actual one and actually provide a complete API documentation as well as a quickstart guide. It will replace the existing site as soon as the next library version is released.</p>"
+    },
+    {
+      "title": "master branch moving to legacy soon",
+      "date": "Oct. 8 2013",
+      "content": "<p>For users of the current <code>master</code> branch, please note that it will renamed to <code>legacy</code> as soon as <code>r1-dev</code> has been completed and tagged as a release. The angular-google-maps website will reflect the api of the new <code>master</code> branch.</p>"
+    },
+    {
+      "title": "AngularJS 1.2 support",
+      "date": "Sept. 21 2013",
+      "content": "<p>angular-google-maps supports AngularJS 1.2 in the <code>r1-dev</code> branch, which will become the <code>master</code> branch once released.</p>"
+    },
+    {
+      "title": "Code overhaul",
+      "date": "May 11 2013",
+      "content": "<p>A new branch has been created which will be used to rewrite most of angular-google-maps and split it in separate directives. This will allow a simplified development process and easier overall integration in your projects.</p><p>Check out the <a href='https://github.com/nlaplante/angular-google-maps/tree/r1-dev'>r1-dev</a> branch now!"
+    }
+  ]
 }

--- a/app/index.html
+++ b/app/index.html
@@ -55,6 +55,7 @@
 					<li ng-class="{'active': $location.path() == '/use'}"><a href="/use" rel="help">Quickstart</a></li>
 					<li ng-class="{'active': $location.path() == '/api'}"><a href="/api" rel="help">API documentation</a></li>
 		            <li ng-class="{'active': $location.path() == '/faq'}"><a href="/faq" rel="help">FAQ</a></li>
+		            <li ng-class="{'active': $location.path() == '/changelog'}"><a href="/changelog" rel="help">Changelog</a></li>
 					<li ng-class="{'active': $location.path() == '/demo'}"><a href="/demo" rel="help">Demo</a></li>	    		
 					<li class="dropdown">
 						<a href="#" class="dropdown-toggle" data-toggle="dropdown">Developer resources <b class="caret"></b></a>
@@ -90,20 +91,19 @@
 	
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.5.2/underscore-min.js"></script>
-	<script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>	
-	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.11/angular.min.js"></script>
-	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.11/angular-route.min.js"></script>
-	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.11/angular-animate.min.js"></script>	
-	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.11/angular-resource.min.js"></script>	
-	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.11/angular-cookies.min.js"></script>	
-	<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.11/angular-sanitize.min.js"></script>
+	<script src="//netdna.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
     <script src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
 
     <!-- build:js scripts/modules.js -->
+    <script src="bower_components/angular/angular.js"></script>
+    <script src="bower_components/angular-route/angular-route.js"></script>
+    <script src="bower_components/angular-animate/angular-animate.js"></script>
+    <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
     <script src="bower_components/share-button/build/share.min.js"></script>
     <script src="bower_components/angular-google-maps/dist/angular-google-maps.min.js"></script>
     <script src="bower_components/highlightjs/highlight.pack.js"></script>
     <script src="bower_components/angular-highlightjs/angular-highlightjs.min.js"></script>
+    <script src="bower_components/angular-semver-sort/angular-semver-sort.js"></script>
     <!-- endbuild -->
 
     <!-- build:js({.tmp,app}) scripts/scripts.js -->
@@ -116,23 +116,16 @@
     <script src="scripts/controllers/headlines.js"></script>    
     <script src="scripts/controllers/footer.js"></script>
     <script src="scripts/controllers/not-found.js"></script>
+    <script src="scripts/controllers/changelog.js"></script>
     <script src="scripts/services/github.js"></script>
     <script src="scripts/services/ga.js"></script>
+    <script src="scripts/services/plnkr.js"></script>
     <script src="scripts/app.js"></script>
     <script src="scripts/directives/rel.js"></script>
     <script src="scripts/directives/share.js"></script>
     <script src="scripts/directives/affix.js"></script>
     <script src="scripts/directives/google-api-ref.js"></script>
+    <script src="scripts/directives/example.js"></script>
     <!-- endbuild -->
-    
-    <!--[if !(lte IE 8)]><!-->
-	<script type="text/javascript">
-	  (function(){
-		var e = document.createElement('script'); e.type='text/javascript'; e.async = true;
-		e.src = document.location.protocol + '//d1agz031tafz8n.cloudfront.net/thedaywefightback.js/widget.min.js';
-		var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(e, s);
-	  })();
-	</script>
-	<!--<![endif]-->
 </body>
 </html>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -47,6 +47,28 @@ angular.module('angularGoogleMapsApp')
         templateUrl: 'views/faq.html',
         controller: 'FAQCtrl'
       })
+      .when('/changelog', {
+      		templateUrl: 'views/changelog.html',
+      		controller: 'ChangeLogCtrl',
+      		reloadOnSearch: false,
+      		resolve: {
+      			changelog: ['$http', '$q', '$log', function ($http, $q, $log) {
+      				var deferred = $q.defer();
+      				
+      				$http({
+      					method: 'GET',
+      					url: '/changelog.json'
+      				}).then(function (res) {
+      					deferred.resolve(res.data);
+      				}, function (error) {
+      					$log.error('could not get /changelog.json', error);
+      					deferred.reject(error);
+      				});
+      				
+      				return deferred.promise;
+      			}]
+      		}
+      })      
       .when('/not-found', {
 		    templateUrl: 'views/404.html',
 		    controller: 'NotFoundCtrl'

--- a/app/scripts/controllers/changelog.js
+++ b/app/scripts/controllers/changelog.js
@@ -1,0 +1,24 @@
+'use strict';
+
+angular.module('angularGoogleMapsApp')
+  .controller('ChangeLogCtrl', ['$scope', '$log', 'changelog', function ($scope, $log, changelog) {
+  
+  	// We need to manipulate the raw changelog json a bit to order by tag number and group commits
+  	// by author.
+  	
+  	var cl = [];
+  	
+  	for (var tag in changelog) {
+  		var commits = changelog[tag];
+  		
+  		cl.push({
+  			tag: tag,
+  			commits: _.groupBy(commits, function (value) {
+  				return value.author;
+	  		})
+  		});
+  	}
+  	
+  	// Everything's set!
+  	$scope.changelog = cl;
+  }]);

--- a/app/scripts/directives/example.js
+++ b/app/scripts/directives/example.js
@@ -1,0 +1,39 @@
+'use strict';
+
+angular.module('angularGoogleMapsApp')
+    .directive('runnableExample', function (openPlnkr) {
+        return {
+            restrict: 'E',
+            templateUrl: '/views/examples/base/template.html',
+            scope: {
+                example: "=example"
+            },
+            controller: ["$scope", "$element", "$http", function($scope, $element, $http) {
+                console.log("Example controller.");
+                $scope.index = true;
+                $scope.script = false;
+
+                $scope.click = function() {
+                    $scope.index = !$scope.index;
+                    $scope.script = !$scope.script;
+                };
+
+                $scope.editPlnkr = function() {
+                    openPlnkr("/views/examples/" + $scope.example);
+                };
+
+                var pres = $element.find('pre');
+                $http.get("/views/examples/" + $scope.example + "/index.html").then(function(index) {
+                    console.log("fetched index", index);
+                    pres[0].innerText = index.data;
+                });
+                $http.get("/views/examples/" + $scope.example + "/script.js").then(function(script) {
+                    console.log("fetched script", script);
+                    pres[1].innerText = script.data;
+                });
+
+                var iframe = $element.find("iframe");
+                iframe.attr("src", "/views/examples/base/base.html?example=" + $scope.example);
+            }]
+        };
+    });

--- a/app/scripts/module.js
+++ b/app/scripts/module.js
@@ -1,3 +1,3 @@
 'use strict';
 
-angular.module('angularGoogleMapsApp', ['ngRoute', 'ngAnimate', 'ngSanitize', 'google-maps', 'hljs']);
+angular.module('angularGoogleMapsApp', ['ngRoute', 'ngAnimate', 'ngSanitize', 'google-maps', 'hljs', 'semverSort']);

--- a/app/scripts/services/plnkr.js
+++ b/app/scripts/services/plnkr.js
@@ -1,0 +1,132 @@
+/**
+ * Shamelessly copied from angularjs https://github.com/angular/angular.js/blob/master/docs/app/src/examples.js
+ * and modified for this use under the MIT License restrictions.
+ */
+angular.module('angularGoogleMapsApp')
+
+    .factory('formPostData', ['$document', function($document) {
+        return function(url, fields) {
+            var form = angular.element('<form style="display: none;" method="post" action="' + url + '" target="_blank"></form>');
+            angular.forEach(fields, function(value, name) {
+                var input = angular.element('<input type="hidden" name="' +  name + '">');
+                input.attr('value', value);
+                form.append(input);
+            });
+            $document.find('body').append(form);
+            form[0].submit();
+            form.remove();
+        };
+    }])
+
+    .factory('openPlnkr', ['formPostData', '$http', '$q', function(formPostData, $http, $q) {
+        return function(exampleFolder) {
+
+            var exampleName = 'Angular Google Maps Example';
+
+            function getInsertionPoint(index, anchor) {
+                return index.content.indexOf(anchor);
+            }
+
+            function getIndex(files) {
+                return files.filter(function(cur) { return cur.name === "index.html"; })[0];
+            }
+
+            function appendContent(index, insertPoint, data) {
+                index.content = index.content.substring(0, insertPoint) + data + index.content.substring(insertPoint);
+            };
+
+            function insertFiles(files, filter, anchor, template) {
+                var list = files.filter(filter);
+                var index = getIndex(files);
+                var insertPoint = getInsertionPoint(index, anchor);
+                var tags = [];
+                list.map(function(cur) {
+                    tags.push(template.replace("$file", cur.name));
+                });
+                appendContent(index, insertPoint, tags.join("\n"));
+            }
+
+            function insertScripts(files) {
+                var filter = function(cur) {
+                    return cur.name.substring(cur.name.length - 3) === ".js";
+                };
+                var template = "<script type='text/javascript' src='$file'></script>";
+                var anchor = "<!--script-->";
+                insertFiles(files, filter, anchor, template);
+            }
+
+            function insertExample(files) {
+                var anchor = "<!--example-->";
+                var index = getIndex(files);
+                var insertionPoint = getInsertionPoint(index, anchor);
+                var exampleIdx = -1;
+                var example = files.filter(function(cur, idx) {
+                    if (cur.name === "example.html") {
+                        exampleIdx = idx;
+                        return true;
+                    }
+
+                    return false;
+                })[0];
+                appendContent(index, insertionPoint, example.content);
+                delete files[exampleIdx];
+            }
+
+            // Load the manifest for the example
+            $http.get(exampleFolder + '/manifest.json')
+                .then(function(response) {
+                    return response.data;
+                })
+                .then(function(manifest) {
+                    var filePromises = [];
+
+                    // Build a pretty title for the Plunkr
+                    var exampleNameParts = manifest.name.split('-');
+                    exampleNameParts.unshift('AngularJS');
+                    angular.forEach(exampleNameParts, function(part, index) {
+                        exampleNameParts[index] = part.charAt(0).toUpperCase() + part.substr(1);
+                    });
+                    exampleName = exampleNameParts.join(' - ');
+
+                    angular.forEach(manifest.files, function(filename) {
+                        filePromises.push($http.get(exampleFolder + '/' + filename, { transformResponse: [] })
+                            .then(function(response) {
+
+                                // The manifests provide the production index file but Plunkr wants
+                                // a straight index.html
+                                if (filename === "index.html") {
+                                    filename = "example.html";
+                                }
+
+                                // Rename plnkr to the main entry point
+                                if (filename === "../base/plnkr.html") {
+                                    filename = "index.html";
+                                }
+
+                                return {
+                                    name: filename,
+                                    content: response.data
+                                };
+                            }));
+                    });
+                    return $q.all(filePromises);
+                })
+                .then(function(files) {
+                    // TODO: Add CSS insertion.
+                    var postData = {};
+                    insertScripts(files);
+                    insertExample(files);
+                    angular.forEach(files, function(file) {
+                        postData['files[' + file.name + ']'] = file.content;
+                    });
+
+                    postData['tags[0]'] = "angularjs";
+                    postData['tags[1]'] = "example";
+                    postData['tags[2]'] = "angular-google-maps";
+                    postData.private = true;
+                    postData.description = exampleName;
+
+                    formPostData('http://plnkr.co/edit/?p=preview', postData);
+                });
+        };
+    }]);

--- a/app/sitemap.xml
+++ b/app/sitemap.xml
@@ -16,4 +16,7 @@
   <url> 
     <loc>http://www.angular-google-maps.org/faq</loc> 
   </url>
+  <url> 
+    <loc>http://www.angular-google-maps.org/changelog</loc> 
+  </url>
 </urlset>

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -255,3 +255,8 @@ ul.separated li:not(:first-child) {
 .bs-callout-info h4 {
     color: #3A87AD;
 }
+
+.plnkr-demo iframe {
+    width: 100%;
+    height: 350px;
+}

--- a/app/views/changelog.html
+++ b/app/views/changelog.html
@@ -1,0 +1,30 @@
+<h1 class="page-header">Change history</h1>
+
+
+<div class="panel-group" id="accordion">
+	<div class="panel panel-default" ng-repeat="tag in changelog | semverReverseSort:'tag'">
+		<div class="panel-heading">
+			<h4 class="panel-title">
+				<a href='' data-toggle="collapse" data-target="#tag{{ $index }}">
+					{{ tag.tag }}
+				</a>
+			</h4>
+		</div>
+		<div id="tag{{ $index }}" class="panel-collapse collapse" ng-class="{in: $first}">
+			<div class="panel-body">
+				<dl>
+					<dd ng-repeat="(author, commits) in tag.commits">
+						<h5>{{ author }}</h5>
+						<ul class="list-unstyled">
+							<li ng-repeat="commit in commits">
+								<a ng-href="https://github.com/nlaplante/angular-google-maps/commit/{{ commit.sha }}" rel="external">{{ commit.sha }}</a> - {{ commit.date | date }}<br>
+								<blockquote>{{ commit.message }}</blockquote>
+							</li>
+						<ul>
+					</dd>
+				<dl>
+			</div>
+		</div>
+	</div>
+</div>
+

--- a/app/views/directive/circle.html
+++ b/app/views/directive/circle.html
@@ -66,6 +66,9 @@ See <a href="https://developers.google.com/maps/documentation/javascript/referen
 	</tbody>
 </table>
 
+<h4>Example</h4>
+<runnable-example example="'circle'"></runnable-example>
+
 <script type="text/ng-template" id="circleTemplate">
 <circle center='{expression}'
   radius='{expression}'

--- a/app/views/directive/google-map.html
+++ b/app/views/directive/google-map.html
@@ -100,6 +100,8 @@
 		</tr>
 	</tbody>
 </table>
+<h4>Example</h4>
+<runnable-example example="'google-map'"></runnable-example>
 
 <script type="text/ng-template" id="googleMapTemplate">
 <google-map center='{expression}' 

--- a/app/views/directive/layer.html
+++ b/app/views/directive/layer.html
@@ -52,6 +52,9 @@
 	</tbody>
 </table>
 
+<h4>Example</h4>
+<runnable-example example="'layer'"></runnable-example>
+
 <script type="text/ng-template" id="layerTemplate">
 <layer type='{string}'
 	namespace='{string}'

--- a/app/views/directive/marker-label.html
+++ b/app/views/directive/marker-label.html
@@ -52,6 +52,9 @@
     </tbody>
 </table>
 
+<h4>Example</h4>
+<runnable-example example="'marker-label'"></runnable-example>
+
 <script type="text/ng-template" id="markerLabelTemplate">
 
 <marker .... >

--- a/app/views/directive/marker.html
+++ b/app/views/directive/marker.html
@@ -48,6 +48,9 @@
 	</tbody>
 </table>
 
+<h4>Example</h4>
+<runnable-example example="'marker'"></runnable-example>
+
 <script type="text/ng-template" id="markerTemplate">
 <marker coords='{expression}'
 	icon='{expression}'

--- a/app/views/directive/markers.html
+++ b/app/views/directive/markers.html
@@ -128,7 +128,7 @@ $scope.clickEventsObject =
     <tr>
         <td>icon</td>
         <td><span class="label label-info">string</span></td>
-        <td>url to the icon image to use for each marker</td>
+        <td>The name of the property of the model in the models array containing the URL to the icon image to use for each marker</td>
     </tr>
     <tr>
         <td>click</td>
@@ -145,6 +145,9 @@ $scope.clickEventsObject =
     </tr>
     </tbody>
 </table>
+
+<h4>Example</h4>
+<runnable-example example="'markers'"></runnable-example>
 
 <script type="text/ng-template" id="markersTemplate">
     <!--

--- a/app/views/directive/polygon.html
+++ b/app/views/directive/polygon.html
@@ -126,6 +126,9 @@ icons = [{
 	</tbody>
 </table>
 
+<h4>Example</h4>
+<runnable-example example="'polygon'"></runnable-example>
+
 <script type="text/ng-template" id="polygonTemplate">
 <polygon path='{expression}'
 	fill='{expression}'

--- a/app/views/directive/polyline.html
+++ b/app/views/directive/polyline.html
@@ -85,6 +85,9 @@ See <a google-api="Polyline">Polyline API</a>.</p>
 	</tbody>
 </table>
 
+<h4>Example</h4>
+<runnable-example example="'polyline'"></runnable-example>
+
 <script type="text/ng-template" id="polylineTemplate">
 <polyline path='{expression}'
 	stroke='{expression}'

--- a/app/views/directive/polylines.html
+++ b/app/views/directive/polylines.html
@@ -132,6 +132,9 @@
     </tbody>
 </table>
 
+<h4>Example</h4>
+<runnable-example example="'polylines'"></runnable-example>
+
 <script type="text/ng-template" id="polylinesTemplate">
 <polyline
         idKey="{expression}"

--- a/app/views/directive/rectangle.html
+++ b/app/views/directive/rectangle.html
@@ -61,6 +61,10 @@ available in the next release.</div>
 	</tbody>
 </table>
 
+<h4>Example</h4>
+<runnable-example example="'rectangle'"></runnable-example>
+
+
 <script type="text/ng-template" id="rectangleTemplate">
 <rectangle bounds='{expression}'
 	fill='{expression}'

--- a/app/views/directive/window.html
+++ b/app/views/directive/window.html
@@ -66,6 +66,9 @@
     </tbody>
 </table>
 
+<h4>Example</h4>
+<runnable-example example="'window'"></runnable-example>
+
 <script type="text/ng-template" id="windowTemplate">
 <window
         coords='{expression}'

--- a/app/views/directive/windows.html
+++ b/app/views/directive/windows.html
@@ -127,6 +127,9 @@
     </tbody>
 </table>
 
+<h4>Example</h4>
+<runnable-example example="'windows'"></runnable-example>
+
 <script type="text/ng-template" id="windowsTemplate">
 <windows
         idKey="{expression}"

--- a/app/views/examples/base/base.html
+++ b/app/views/examples/base/base.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns:ng="http://angularjs.org/" ng-app="appMaps">
+
+<head>
+    <meta charset="utf-8" />
+    <title>AngularJS Plunker</title>
+    <script src="//maps.googleapis.com/maps/api/js?libraries=weather,geometry,visualization&sensor=false&language=en&v=3.14"></script>
+    <script src="../../../bower_components/angular/angular.js" ></script>
+    <script src="../../../bower_components/lodash/dist/lodash.underscore.js"></script>
+    <script src="../../../bower_components/angular-google-maps/dist/angular-google-maps.min.js"></script>
+    <script src="example.js"></script>
+    <style type="text/css">
+        html, body, #map_canvas {
+            height: 100%;
+            width: 100%;
+            margin: 0px;
+        }
+
+        #map_canvas {
+            position: relative;
+        }
+
+        .angular-google-map-container {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            right: 0;
+            left: 0;
+        }
+    </style>
+</head>
+
+<body ng-controller="exampleCtrl">
+</body>
+
+</html>

--- a/app/views/examples/base/example.js
+++ b/app/views/examples/base/example.js
@@ -1,0 +1,74 @@
+var app = angular.module("appMaps", ['google-maps'])
+    .config(function($controllerProvider) {
+        // Override the normal controller process so controllers can be late loaded.
+        app.controller = $controllerProvider.register;
+    })
+    .controller("exampleCtrl", function($scope, $element, $document, $compile, $http, $q, $controller) {
+        function getParameterByName(name) {
+            name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+            var regex = new RegExp("[\\?&]" + name + "=([^&#]*)");
+            var results = regex.exec(location.search);
+            return results == null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+        }
+
+        var example = getParameterByName("example");
+        var examplePath = "/views/examples/" + example + "/";
+
+        // Get the manifest to determine what files to load and what order (based on manifest definition).
+        $http.get(examplePath + "manifest.json").then(function(manifest) {
+            return manifest.data
+        }).then(function(manifest) {
+            var promises = [];
+            manifest.files.map(function(cur) {
+                // Don't include plnkr template
+                if (cur === "../base/plnkr.html") {
+                    return;
+                }
+
+                promises.push($http.get(examplePath + cur).then(function(response) {
+                    return {
+                        name: cur,
+                        content: response.data
+                    };
+                }));
+            });
+
+            return $q.all(promises);
+        }).then(function(files) {
+            // Get all the javascript files
+            var js = files.filter(function(cur) {
+                return cur.name.substring(cur.name.length - 3) === ".js";
+            });
+
+            // Get all the html files
+            var html = files.filter(function(cur) {
+                return cur.name.substring(cur.name.length - 5) === ".html";
+            });
+
+            // Load all the js files before html, so all controllers are registered
+            js.map(function(cur) {
+                var module = angular.module;
+                // Trick to lazy load controllers into this loaded module, basically
+                // replace the controller function with the function for the controllerProvider
+                // register function. The controller function is replace above in the module config
+                angular.module = function(name, deps) {
+                    console.log("Loading module: " + name);
+                    if (name === "appMaps") {
+                        return app;
+                    } else {
+                        return module(name, deps)
+                    }
+                };
+                eval(cur.content);
+                angular.module = module;
+            });
+
+            // Now add all the html
+            html.map(function(cur) {
+                $http.get(examplePath + cur.name).then(function(index) {
+                    $element.append($compile(index.data)($scope));
+                });
+            });
+
+        });
+    });

--- a/app/views/examples/base/plnkr.html
+++ b/app/views/examples/base/plnkr.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns:ng="http://angularjs.org/" ng-app="appMaps">
+
+<head>
+    <meta charset="utf-8" />
+    <title>AngularJS Plunker</title>
+    <link rel="stylesheet" href="style.css" />
+    <script src="//maps.googleapis.com/maps/api/js?libraries=weather,geometry,visualization&sensor=false&language=en&v=3.14"></script>
+    <script data-require="angular.js@1.2.x" src="https://code.angularjs.org/1.2.16/angular.js" data-semver="1.2.16"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.underscore.js"></script>
+    <script src="http://rawgithub.com/nlaplante/angular-google-maps/master/dist/angular-google-maps.js"></script>
+    <!--script-->
+    <!--css-->
+    <style type="text/css">
+        html, body, #map_canvas {
+            height: 100%;
+            width: 100%;
+            margin: 0px;
+        }
+
+        #map_canvas {
+            position: relative;
+        }
+
+        .angular-google-map-container {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            right: 0;
+            left: 0;
+        }
+    </style>
+</head>
+
+<body>
+    <!--example-->
+</body>
+
+</html>

--- a/app/views/examples/base/template.html
+++ b/app/views/examples/base/template.html
@@ -1,0 +1,16 @@
+<div>
+    <div>
+        <button ng-click="click()">index.html</button>
+        <button ng-click="click()">script.js</button>
+        <button style="float:right" ng-click="editPlnkr()">Edit in Plnkr</button>
+    </div>
+    <div ng-show="index">
+        <pre ng-non-bindable></pre>
+    </div>
+    <div ng-show="script">
+        <pre ng-non-bindable></pre>
+    </div>
+    <div style="width:100%; height: 350px; padding:4px;">
+        <iframe style="width: 100%; height: 100%"></iframe>
+    </div>
+</div>

--- a/app/views/examples/circle/index.html
+++ b/app/views/examples/circle/index.html
@@ -1,0 +1,6 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options">
+        <circle ng-repeat="c in circles track by c.id" center="c.center" stroke="c.stroke" fill="c.fill" radius="c.radius"
+                visible="c.visible" geodesic="c.geodesic" editable="c.editable" draggable="c.draggable" clickable="c.clickable"></circle>
+    </google-map>
+</div>

--- a/app/views/examples/circle/manifest.json
+++ b/app/views/examples/circle/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "circle",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/circle/script.js
+++ b/app/views/examples/circle/script.js
@@ -1,0 +1,29 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope) {
+        $scope.map = {center: {latitude: 44, longitude: -108 }, zoom: 4 };
+        $scope.options = {scrollwheel: false};
+        $scope.circles = [
+            {
+                id: 1,
+                center: {
+                    latitude: 44,
+                    longitude: -108
+                },
+                radius: 500000,
+                stroke: {
+                    color: '#08B21F',
+                    weight: 2,
+                    opacity: 1
+                },
+                fill: {
+                    color: '#08B21F',
+                    opacity: 0.5
+                },
+                geodesic: true, // optional: defaults to false
+                draggable: true, // optional: defaults to false
+                clickable: true, // optional: defaults to true
+                editable: true, // optional: defaults to false
+                visible: true // optional: defaults to true
+            }
+        ];
+    });

--- a/app/views/examples/google-map/index.html
+++ b/app/views/examples/google-map/index.html
@@ -1,0 +1,3 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options"></google-map>
+</div>

--- a/app/views/examples/google-map/manifest.json
+++ b/app/views/examples/google-map/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "google-map",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/google-map/script.js
+++ b/app/views/examples/google-map/script.js
@@ -1,0 +1,5 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope) {
+        $scope.map = {center: {latitude: 51.219053, longitude: 4.404418 }, zoom: 14 };
+        $scope.options = {scrollwheel: false};
+    });

--- a/app/views/examples/layer/index.html
+++ b/app/views/examples/layer/index.html
@@ -1,0 +1,5 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options">
+        <layer namespace="weather" type="WeatherLayer" show="showWeather"></layer>
+    </google-map>
+</div>

--- a/app/views/examples/layer/manifest.json
+++ b/app/views/examples/layer/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "layer",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/layer/script.js
+++ b/app/views/examples/layer/script.js
@@ -1,0 +1,6 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope) {
+        $scope.map = {center: {latitude: 51.219053, longitude: 4.404418 }, zoom: 4 };
+        $scope.options = {scrollwheel: false};
+        $scope.showWeather = true;
+    });

--- a/app/views/examples/marker-label/index.html
+++ b/app/views/examples/marker-label/index.html
@@ -1,0 +1,7 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options">
+        <marker coords="marker.coords">
+            <marker-label content="marker.title" anchor="2 0" class="marker-labels"/>
+        </marker>
+    </google-map>
+</div>

--- a/app/views/examples/marker-label/manifest.json
+++ b/app/views/examples/marker-label/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "markers-label",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/marker-label/script.js
+++ b/app/views/examples/marker-label/script.js
@@ -1,0 +1,12 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope) {
+        $scope.map = {center: {latitude: 40, longitude: -99 }, zoom: 12 }
+        $scope.options = {scrollwheel: false};
+        $scope.marker = {
+            title: "Fancy Title!",
+            coords: {
+                latitude: 40,
+                longitude: -99
+            }
+        }
+    });

--- a/app/views/examples/marker/index.html
+++ b/app/views/examples/marker/index.html
@@ -1,0 +1,6 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options">
+        <marker coords="marker.coords" options="marker.options" events="marker.events" >
+        </marker>
+    </google-map>
+</div>

--- a/app/views/examples/marker/manifest.json
+++ b/app/views/examples/marker/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "marker",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/marker/script.js
+++ b/app/views/examples/marker/script.js
@@ -1,0 +1,19 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope, $log) {
+        $scope.map = {center: {latitude: 40.1451, longitude: -99.6680 }, zoom: 4 }
+        $scope.options = {scrollwheel: false};
+        $scope.marker = {
+            coords: {
+                latitude: 40.1451,
+                longitude: -99.6680
+            },
+            options: { draggable: true },
+            events: {
+                dragend: function (marker, eventName, args) {
+                    $log.log('marker dragend');
+                    $log.log(marker.getPosition().lat());
+                    $log.log(marker.getPosition().lng());
+                }
+            }
+        }
+    });

--- a/app/views/examples/markers/index.html
+++ b/app/views/examples/markers/index.html
@@ -1,0 +1,6 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options" bounds="map.bounds">
+        <markers models="randomMarkers" coords="'self'" icon="'icon'" click="'onClicked'">
+        </markers>
+    </google-map>
+</div>

--- a/app/views/examples/markers/manifest.json
+++ b/app/views/examples/markers/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "markers",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/markers/script.js
+++ b/app/views/examples/markers/script.js
@@ -1,0 +1,37 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope) {
+        $scope.map = {center: {latitude: 40.1451, longitude: -99.6680 }, zoom: 4, bounds: {}};
+        $scope.options = {scrollwheel: false};
+        var createRandomMarker = function (i, bounds, idKey) {
+            var lat_min = bounds.southwest.latitude,
+                lat_range = bounds.northeast.latitude - lat_min,
+                lng_min = bounds.southwest.longitude,
+                lng_range = bounds.northeast.longitude - lng_min;
+
+            if (idKey == null) {
+                idKey = "id";
+            }
+
+            var latitude = lat_min + (Math.random() * lat_range);
+            var longitude = lng_min + (Math.random() * lng_range);
+            var ret = {
+                latitude: latitude,
+                longitude: longitude,
+                title: 'm' + i
+            };
+            ret[idKey] = i;
+            return ret;
+        };
+        $scope.randomMarkers = [];
+        // Get the bounds from the map once it's loaded
+        $scope.$watch(function() { return $scope.map.bounds; }, function(nv, ov) {
+            // Only need to regenerate once
+            if (!ov.southwest && nv.southwest) {
+                var markers = [];
+                for (var i = 0; i < 50; i++) {
+                    markers.push(createRandomMarker(i, $scope.map.bounds))
+                }
+                $scope.randomMarkers = markers;
+            }
+        }, true);
+    });

--- a/app/views/examples/polygon/index.html
+++ b/app/views/examples/polygon/index.html
@@ -1,0 +1,6 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options" bounds="map.bounds">
+        <polygon static="true" ng-repeat="p in polygons track by p.id" path="p.path" stroke="p.stroke" visible="p.visible"
+                 geodesic="p.geodesic" fill="p.fill" fit="false" editable="p.editable" draggable="p.draggable"></polygon>
+    </google-map>
+</div>

--- a/app/views/examples/polygon/manifest.json
+++ b/app/views/examples/polygon/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "polygon",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/polygon/script.js
+++ b/app/views/examples/polygon/script.js
@@ -1,0 +1,35 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope) {
+        $scope.map = {center: {latitude: 40.1451, longitude: -99.6680 }, zoom: 4, bounds: {}};
+        $scope.polygons = [
+            {
+                id: 1,
+                path: [
+                    {
+                        latitude: 50,
+                        longitude: -80
+                    },
+                    {
+                        latitude: 30,
+                        longitude: -120
+                    },
+                    {
+                        latitude: 20,
+                        longitude: -95
+                    }
+                ],
+                stroke: {
+                    color: '#6060FB',
+                    weight: 3
+                },
+                editable: true,
+                draggable: true,
+                geodesic: false,
+                visible: true,
+                fill: {
+                    color: '#ff0000',
+                    opacity: 0.8
+                }
+            }
+        ];
+    });

--- a/app/views/examples/polyline/index.html
+++ b/app/views/examples/polyline/index.html
@@ -1,0 +1,6 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options" bounds="map.bounds">
+        <polyline ng-repeat="p in polylines" path="p.path" stroke="p.stroke" visible='p.visible'
+                  geodesic='p.geodesic' fit="false" editable="p.editable" draggable="p.draggable" icons='p.icons'></polyline>
+    </google-map>
+</div>

--- a/app/views/examples/polyline/manifest.json
+++ b/app/views/examples/polyline/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "polyline",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/polyline/script.js
+++ b/app/views/examples/polyline/script.js
@@ -1,0 +1,97 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope) {
+        $scope.map = {center: {latitude: 40.1451, longitude: -99.6680 }, zoom: 4, bounds: {}};
+        $scope.polylines = [
+            {
+                id: 1,
+                path: [
+                    {
+                        latitude: 45,
+                        longitude: -74
+                    },
+                    {
+                        latitude: 30,
+                        longitude: -89
+                    },
+                    {
+                        latitude: 37,
+                        longitude: -122
+                    },
+                    {
+                        latitude: 60,
+                        longitude: -95
+                    }
+                ],
+                stroke: {
+                    color: '#6060FB',
+                    weight: 3
+                },
+                editable: true,
+                draggable: true,
+                geodesic: true,
+                visible: true,
+                icons: [{
+                    icon: {
+                        path: google.maps.SymbolPath.BACKWARD_OPEN_ARROW
+                    },
+                    offset: '25px',
+                    repeat: '50px'
+                }]
+            },
+            {
+                id: 2,
+                path: [
+                    {
+                        latitude: 47,
+                        longitude: -74
+                    },
+                    {
+                        latitude: 32,
+                        longitude: -89
+                    },
+                    {
+                        latitude: 39,
+                        longitude: -122
+                    },
+                    {
+                        latitude: 62,
+                        longitude: -95
+                    }
+                ],
+                stroke: {
+                    color: '#6060FB',
+                    weight: 3
+                },
+                editable: true,
+                draggable: true,
+                geodesic: true,
+                visible: true,
+                icons: [{
+                    icon: {
+                        path: google.maps.SymbolPath.BACKWARD_OPEN_ARROW
+                    },
+                    offset: '25px',
+                    repeat: '50px'
+                }]
+            },
+            {
+                id: 3,
+                path: google.maps.geometry.encoding.decodePath("uowfHnzb}Uyll@i|i@syAcx}Cpj[_wXpd}AhhCxu[ria@_{AznyCnt^|re@nt~B?m|Awn`G?vk`RzyD}nr@uhjHuqGrf^ren@"),
+                stroke: {
+                    color: '#4EAE47',
+                    weight: 3
+                },
+                editable: false,
+                draggable: false,
+                geodesic: false,
+                visible: true,
+                icons: [{
+                    icon: {
+                        path: google.maps.SymbolPath.BACKWARD_OPEN_ARROW
+                    },
+                    offset: '25px',
+                    repeat: '50px'
+                }]
+            }
+        ];
+    });

--- a/app/views/examples/polylines/index.html
+++ b/app/views/examples/polylines/index.html
@@ -1,0 +1,6 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options" bounds="map.bounds">
+        <polylines models="polylines" path="'path'" stroke="'stroke'" visible="'visible'"
+                  geodesic="'geodesic'" fit="false" editable="'p.editable'" draggable="'draggable'" icons="'icons'"></polylines>
+    </google-map>
+</div>

--- a/app/views/examples/polylines/manifest.json
+++ b/app/views/examples/polylines/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "polylines",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/polylines/script.js
+++ b/app/views/examples/polylines/script.js
@@ -1,0 +1,97 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope) {
+        $scope.map = {center: {latitude: 40.1451, longitude: -99.6680 }, zoom: 4, bounds: {}};
+        $scope.polylines = [
+            {
+                id: 1,
+                path: [
+                    {
+                        latitude: 45,
+                        longitude: -74
+                    },
+                    {
+                        latitude: 30,
+                        longitude: -89
+                    },
+                    {
+                        latitude: 37,
+                        longitude: -122
+                    },
+                    {
+                        latitude: 60,
+                        longitude: -95
+                    }
+                ],
+                stroke: {
+                    color: '#6060FB',
+                    weight: 3
+                },
+                editable: true,
+                draggable: true,
+                geodesic: true,
+                visible: true,
+                icons: [{
+                    icon: {
+                        path: google.maps.SymbolPath.BACKWARD_OPEN_ARROW
+                    },
+                    offset: '25px',
+                    repeat: '50px'
+                }]
+            },
+            {
+                id: 2,
+                path: [
+                    {
+                        latitude: 47,
+                        longitude: -74
+                    },
+                    {
+                        latitude: 32,
+                        longitude: -89
+                    },
+                    {
+                        latitude: 39,
+                        longitude: -122
+                    },
+                    {
+                        latitude: 62,
+                        longitude: -95
+                    }
+                ],
+                stroke: {
+                    color: '#6060FB',
+                    weight: 3
+                },
+                editable: true,
+                draggable: true,
+                geodesic: true,
+                visible: true,
+                icons: [{
+                    icon: {
+                        path: google.maps.SymbolPath.BACKWARD_OPEN_ARROW
+                    },
+                    offset: '25px',
+                    repeat: '50px'
+                }]
+            },
+            {
+                id: 3,
+                path: google.maps.geometry.encoding.decodePath("uowfHnzb}Uyll@i|i@syAcx}Cpj[_wXpd}AhhCxu[ria@_{AznyCnt^|re@nt~B?m|Awn`G?vk`RzyD}nr@uhjHuqGrf^ren@"),
+                stroke: {
+                    color: '#4EAE47',
+                    weight: 3
+                },
+                editable: false,
+                draggable: false,
+                geodesic: false,
+                visible: true,
+                icons: [{
+                    icon: {
+                        path: google.maps.SymbolPath.BACKWARD_OPEN_ARROW
+                    },
+                    offset: '25px',
+                    repeat: '50px'
+                }]
+            }
+        ];
+    });

--- a/app/views/examples/rectangle/index.html
+++ b/app/views/examples/rectangle/index.html
@@ -1,0 +1,5 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options" bounds="map.bounds">
+        <rectangle bounds="bounds" fill="'#FFFFFF .5'"></rectangle>
+    </google-map>
+</div>

--- a/app/views/examples/rectangle/manifest.json
+++ b/app/views/examples/rectangle/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "polylines",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/rectangle/script.js
+++ b/app/views/examples/rectangle/script.js
@@ -1,0 +1,14 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope) {
+        $scope.map = {center: {latitude: 2, longitude: 2}, zoom: 6, bounds: {}};
+        $scope.bounds =  {
+            sw: {
+                latitude: 0,
+                longitude: 0
+            },
+            ne: {
+                latitude: 4,
+                longitude: 4
+            }
+        };
+    });

--- a/app/views/examples/window/index.html
+++ b/app/views/examples/window/index.html
@@ -1,0 +1,9 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options">
+        <marker coords="marker.coords" options="marker.options" events="marker.events" >
+            <window show="show">
+                <div>{{title}}</div>
+            </window>
+        </marker>
+    </google-map>
+</div>

--- a/app/views/examples/window/manifest.json
+++ b/app/views/examples/window/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "window",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/window/script.js
+++ b/app/views/examples/window/script.js
@@ -1,0 +1,14 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope, $log) {
+        $scope.map = {center: {latitude: 40.1451, longitude: -99.6680 }, zoom: 4 }
+        $scope.options = {scrollwheel: false};
+        $scope.marker = {
+            coords: {
+                latitude: 40.1451,
+                longitude: -99.6680
+            },
+            show: false
+        };
+
+        $scope.title = "Window Title!";
+    });

--- a/app/views/examples/windows/index.html
+++ b/app/views/examples/windows/index.html
@@ -1,0 +1,9 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options" bounds="map.bounds">
+        <markers models="randomMarkers" coords="'self'" icon="'icon'" click="'onClick'">
+            <windows show="show">
+                <div ng-non-bindable>{{title}}</div>
+            </windows>
+        </markers>
+    </google-map>
+</div>

--- a/app/views/examples/windows/manifest.json
+++ b/app/views/examples/windows/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "windows",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/windows/script.js
+++ b/app/views/examples/windows/script.js
@@ -1,0 +1,42 @@
+angular.module('appMaps', ['google-maps'])
+    .controller('mainCtrl', function($scope) {
+        $scope.map = {center: {latitude: 40.1451, longitude: -99.6680 }, zoom: 4, bounds: {}};
+        $scope.options = {scrollwheel: false};
+        var createRandomMarker = function (i, bounds, idKey) {
+            var lat_min = bounds.southwest.latitude,
+                lat_range = bounds.northeast.latitude - lat_min,
+                lng_min = bounds.southwest.longitude,
+                lng_range = bounds.northeast.longitude - lng_min;
+
+            if (idKey == null) {
+                idKey = "id";
+            }
+
+            var latitude = lat_min + (Math.random() * lat_range);
+            var longitude = lng_min + (Math.random() * lng_range);
+            var ret = {
+                latitude: latitude,
+                longitude: longitude,
+                title: 'm' + i,
+                show: false
+            };
+            ret.onClick = function() {
+                console.log("Clicked!");
+                ret.show = !ret.show;
+            };
+            ret[idKey] = i;
+            return ret;
+        };
+        $scope.randomMarkers = [];
+        // Get the bounds from the map once it's loaded
+        $scope.$watch(function() { return $scope.map.bounds; }, function(nv, ov) {
+            // Only need to regenerate once
+            if (!ov.southwest && nv.southwest) {
+                var markers = [];
+                for (var i = 0; i < 50; i++) {
+                    markers.push(createRandomMarker(i, $scope.map.bounds))
+                }
+                $scope.randomMarkers = markers;
+            }
+        }, true);
+    });

--- a/bower.json
+++ b/bower.json
@@ -11,10 +11,11 @@
     "angular-resource": "~1.2.5",
     "angular-cookies": "~1.2.5",
     "angular-sanitize": "~1.2.5",
-    "angular-google-maps": "~1.0.5",
+    "angular-google-maps": "~1.1.0",
     "underscore": "~1.5.2",
     "angular-highlightjs": "~0.2.5",
-    "share-button": "~0.0.3"
+    "share-button": "~0.0.3",
+    "angular-semver-sort": "~0.2.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.5",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,6 +20,8 @@ module.exports = function(config) {
       'app/bower_components/angular-mocks/angular-mocks.js',
       'app/bower_components/underscore/underscore-min.js',
       'app/bower_components/angular-google-maps/dist/angular-google-maps.js',
+      'app/bower_components/angular-highlightjs/angular-highlightjs.js',
+      'app/bower_components/angular-semver-sort/angular-semver-sort.js',
       'app/scripts/module.js',      
       'app/scripts/controllers/*.js',
       'app/scripts/services/*.js',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "name": "angular-google-maps",
   "description": "Website for angular-google-maps",
   "version": "0.0.0",
-  "dependencies": {},
+  "dependencies": {
+    "grunt-git-log-json": "0.0.3"
+  },
   "repository": "https://github.com/nlaplante/angular-google-maps",
   "devDependencies": {
     "grunt": "~0.4.1",
@@ -45,7 +47,8 @@
     "karma-ie-launcher": "~0.1.1",
     "grunt-cli": "~0.1.11",
     "karma-story-reporter": "~0.2.2",
-    "karma-mocha-reporter": "~0.2.0"
+    "karma-mocha-reporter": "~0.2.0",
+    "grunt-git-log-json": "~0.0.4"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/test/spec/controllers/changelog.js
+++ b/test/spec/controllers/changelog.js
@@ -1,0 +1,88 @@
+'use strict';
+
+describe('Controller: ChangeLogCtrl', function () {
+
+  // load the controller's module
+  beforeEach(module('angularGoogleMapsApp'));
+
+  var ChangelogCtrl,
+    scope;
+
+  // Initialize the controller and a mock scope
+  beforeEach(inject(function ($controller, $rootScope) {
+    scope = $rootScope.$new();
+    ChangelogCtrl = $controller('ChangeLogCtrl', {
+      $scope: scope,
+      changelog: {
+      	"1.1.0": [{      			
+      			sha: "095722",
+      			author: 'Nicolas Laplante <nicolas.laplante@gmail.com>',
+      			date: 'Sat May 17 13:13:20 2014 -0400',
+      			message: 'Test commit for ChangelogCtrl spec 1'
+      		}, {      			
+      			sha: "095723",
+      			author: 'Nicolas Laplante <nicolas.laplante@gmail.com>',
+      			date: 'Sat May 17 13:17:48 2014 -0400',
+      			message: 'Test commit for ChangelogCtrl spec 2'
+      		}, {
+	      		sha: "095724",
+      			author: 'John Doe <jdoe@hotmail.com>',
+      			date: 'Sat May 17 13:17:48 2014 -0400',
+      			message: 'Test commit for ChangelogCtrl spec 2'
+      		}
+      	],
+      	'1.0.18': [{      			
+      			sha: "095722",
+      			author: 'Nicolas Laplante <nicolas.laplante@gmail.com>',
+      			date: 'Sat May 17 13:13:20 2014 -0400',
+      			message: 'Test commit for ChangelogCtrl spec 1'
+      		}, {      			
+      			sha: "095723",
+      			author: 'Nicolas Laplante <nicolas.laplante@gmail.com>',
+      			date: 'Sat May 17 13:17:48 2014 -0400',
+      			message: 'Test commit for ChangelogCtrl spec 2'
+      		}, {
+	      		sha: "095724",
+      			author: 'John Doe <jdoe@hotmail.com>',
+      			date: 'Sat May 17 13:17:48 2014 -0400',
+      			message: 'Test commit for ChangelogCtrl spec 2'
+      		}     	
+      	],
+      	'1.0.19': [{      			
+      			sha: "095722",
+      			author: 'Nicolas Laplante <nicolas.laplante@gmail.com>',
+      			date: 'Sat May 17 13:13:20 2014 -0400',
+      			message: 'Test commit for ChangelogCtrl spec 1'
+      		}, {      			
+      			sha: "095723",
+      			author: 'Nicolas Laplante <nicolas.laplante@gmail.com>',
+      			date: 'Sat May 17 13:17:48 2014 -0400',
+      			message: 'Test commit for ChangelogCtrl spec 2'
+      		}, {
+	      		sha: "095724",
+      			author: 'John Doe <jdoe@hotmail.com>',
+      			date: 'Sat May 17 13:17:48 2014 -0400',
+      			message: 'Test commit for ChangelogCtrl spec 2'
+      		}      	
+      	]
+      }
+    });
+  }));
+
+  it('should attach the changelog to the scope', function () {
+    expect(scope.changelog.length).not.toBe(0);
+  });
+  
+  it('should convert changelog data to suitable format for template', function () {
+  	expect(scope.changelog[0].tag).not.toBe(null);
+  	expect(scope.changelog[0].commits).not.toBe(null);
+  });
+  
+  it('should group commits by author', function () {
+	expect(scope.changelog[0].commits['Nicolas Laplante <nicolas.laplante@gmail.com>']).not.toBe(null);
+  	expect(scope.changelog[0].commits['Nicolas Laplante <nicolas.laplante@gmail.com>'].length).toBe(2);
+  	
+  	expect(scope.changelog[0].commits['John Doe <jdoe@hotmail.com>']).not.toBe(null);
+  	expect(scope.changelog[0].commits['John Doe <jdoe@hotmail.com>'].length).toBe(1);
+  });
+});


### PR DESCRIPTION
@rickhuizinga @nlaplante @nmccready 
I have added a directive allows us to add interactive examples the documentation fairly easily. There are some items needed to fully flesh it out, but this will definitely get us where we want to be today.

I may have some file changes in here that are just merge artifacts, such as the .travis.yml. At any rate, let me know if you see anything. Sorry for the large commit, but this didn't seem like a piecemeal type of task.

Outstanding Issues:
- Only script.js and index.html allowed right now as code examples. More can be added to the plnkr, but they wouldn't show up on the website.
- Maps don't always center correctly, likely due to loading in an iframe. Need access to the map object I think to make this work correctly. 
- Styling of code is non-existent. It would be nice to get some syntax highlighting going on there.
