### PR TITLE
Add 'dragging' attribute to <google-map> table docs

### DIFF
--- a/app/views/directive/google-map.html
+++ b/app/views/directive/google-map.html
@@ -70,6 +70,11 @@
 			<td><code>true</code> if map must be draggable, <code>false</code> otherwise</td>
 		</tr>
 		<tr>
+			<td>draging</td>
+			<td><span class="label label-default">string</span></td>
+			<td><code>true</code> while map is dragging state, <code>false</code> otherwise</td>
+		</tr>
+		<tr>
 			<td>refresh</td>
 			<td><span class="label label-default">expression</span></td>
 			<td>Expression which, if it evaluates to <code>true</code>, will trigger a map refresh. Useful when the map is


### PR DESCRIPTION
This attribute wasn't explained in the docs. Went through code and found what it's for. Updating docs to help other newbs.
