### PR TITLE
added documentation for mapControl directive

### DIFF
--- a/app/scripts/controllers/api.js
+++ b/app/scripts/controllers/api.js
@@ -6,6 +6,7 @@ angular.module('angularGoogleMapsApp').controller('ApiCtrl', function ($scope, $
         'google-map',
         'circle',
         'layer',
+        'map-control',
         'marker',
         'marker-label',
         'markers',

--- a/app/views/directive/map-control.html
+++ b/app/views/directive/map-control.html
@@ -1,0 +1,53 @@
+<p>The <code>map-control</code> directive is used to add custom controls to the maps UI.</p>
+	
+<h4>Usage</h4>
+
+<div hljs language="html" include="'controlTemplate'"></div>
+
+<h4>Parameters</h4>
+
+<p class="muted">Required properties are in <span class="text-error">red</span>.</p>
+
+<table class="table table-bordered table-striped">
+	<thead>
+		<tr>
+			<th>Param</th>
+			<th>Type</th>
+			<th>Details</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>template</td>
+			<td><span class="label label-danger">expression</span></td>
+			<td>Template to be used for the control's content.</td>
+  	</tr>
+		<tr>
+			<td>position</td>
+			<td><span class="label label-info">string</span></td>
+			<td>String representing the position of the control within the map UI. Should be of the form <code>"top-left"</code> or <code>"TOP_LEFT"</code>. Defaults to <code>"TOP_CENTER"</code>. See <a href="https://developers.google.com/maps/documentation/javascript/controls#ControlPositioning" rel="external">Control Positioning</a> for position options and behaviour.</td>
+		</tr>
+		<tr>
+			<td>controller</td>
+			<td><span class="label label-info">expression|function</span></td>
+			<td>Controller applied to the control's template.</td>
+		</tr>
+		<tr>
+			<td>index</td>
+			<td><span class="label label-info">expression</span>
+			<td><p>Index applied to the map control. Controls are placed at each location by the order of the index; controls with a lower index are placed first.</p><p>By default, all custom controls are placed after any API default controls but this can be overridden using a negative index. Custom contols cannot be placed to the left of the logo or the right of the copyrights.</p></td>
+		</tr>
+	</tbody>
+</table>
+
+<!-- <h4>Example</h4>
+<runnable-example example="'map-control'"></runnable-example> -->
+
+<script type="text/ng-template" id="controlTemplate">
+<map-control
+	template='{expression}'
+	position="'{string}'"
+	controller='{expression}'
+	index='{expression}'>
+</map-control>
+</script>

--- a/app/views/examples/map-control/index.html
+++ b/app/views/examples/map-control/index.html
@@ -1,0 +1,5 @@
+<div id="map_canvas" ng-controller="mainCtrl">
+    <google-map center="map.center" zoom="map.zoom" draggable="true" options="options">
+        <map-control template="control.tpl.html" position="top-right" controller="controlCtrl"index="-1"></map-control>
+    </google-map>
+</div>

--- a/app/views/examples/map-control/manifest.json
+++ b/app/views/examples/map-control/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "map-control",
+    "files": ["index.html", "script.js", "../base/plnkr.html"]
+}

--- a/app/views/examples/map-control/script.js
+++ b/app/views/examples/map-control/script.js
@@ -1,0 +1,16 @@
+angular.module('appMaps', ['google-maps'])
+    .run(function ($templateCache) {
+        $templateCache.put('control.tpl.html', '<button class="btn btn-sm btn-primary" ng-class="{\'btn-warning\': danger}" ng-click="controlClick()">{{controlText}}</button>');
+    })
+    .controller('mainCtrl', function ($scope, $log) {
+        $scope.map = {center: {latitude: 40.1451, longitude: -99.6680 }, zoom: 4 }
+        $scope.options = {scrollwheel: false};
+    })
+    .controller('controlCtrl', function ($scope) {
+        $scope.controlText = 'I\'m a custom control';
+        $scope.danger = false;
+        $scope.controlClick = function () {
+            $scope.danger = !$scope.danger;
+            alert('custom control clicked!')
+        };
+    });


### PR DESCRIPTION
Have added docs for the `map-control` directive.

The example is commented out as does not run due to:
1. directive not in current release that website references and, more notably,
2. when adding a second controller to the `script.js` file for the example it throws an error on the call to `eval(cur.content)` **(base/example.js:62)** as it loops through the .js files. I am not quite sure what this is doing exactly so not sure how to fix it. Just need to add a template to `$templateCache` and define a controller for the `map-control` directive, is there another way I should be doing this?
