### PR TITLE
corrected code example for polylines

### DIFF
--- a/app/views/directive/polylines.html
+++ b/app/views/directive/polylines.html
@@ -148,6 +148,6 @@
         fit='{string or boolean}'
 
         static='{expression}'>
-</polyline>
+</polylines>
 </script>
 


### PR DESCRIPTION
added 's' to polyline in polyline directive example making it polylines. A subtle difference but functionally different to the singular polyline directive.

In response to issue I opened a couple of days ago: https://github.com/nlaplante/angular-google-maps/issues/563
