### PR TITLE
Bug Fix: Click handler missing from Markers w/ option changes

### DIFF
--- a/dist/angular-google-maps.js
+++ b/dist/angular-google-maps.js
@@ -5893,12 +5893,13 @@ Original idea from: http://stackoverflow.com/questions/22758950/google-map-drawi
                   this.scope.gMarker.setMap(null);
                 }
 				
-                this.setGMarker(new google.maps.Marker(this.createMarkerOptions(scope.coords, scope.icon, scope.options, scope.map)));
+                var ret = this.setGMarker(new google.maps.Marker(this.createMarkerOptions(scope.coords, scope.icon, scope.options, scope.map)));
 				this.listener = google.maps.event.addListener(this.scope.gMarker, 'click', function() {
 					if (_this.doClick && (scope.click != null)) {
 					  return _this.scope.click();
 					}
 				});
+				return ret;
               }
           }
         };


### PR DESCRIPTION
Was having an issue with the click handler not being attached to Markers after their options had changed (tested with visibility and opacity). Strangely the issue occurred after changing the options property -twice-. This update seems to fix the issue by adding the click listener to the new Google Marker created whenever options are updated.
