### PR TITLE
Issue 659: Add required single quotes around show

### DIFF
--- a/app/views/examples/windows/index.html
+++ b/app/views/examples/windows/index.html
@@ -1,7 +1,7 @@
 <div id="map_canvas" ng-controller="mainCtrl">
     <google-map center="map.center" zoom="map.zoom" draggable="true" options="options" bounds="map.bounds">
         <markers models="randomMarkers" coords="'self'" icon="'icon'" click="'onClick'">
-            <windows show="show">
+            <windows show="'show'">
                 <div ng-non-bindable>{{title}}</div>
             </windows>
         </markers>


### PR DESCRIPTION
The windows directive show attribute value requires single quotes inside the double quotes
