### PR TITLE
added draggable to scope of map directive

### DIFF
--- a/src/coffee/directives/api/map.coffee
+++ b/src/coffee/directives/api/map.coffee
@@ -72,7 +72,7 @@ angular.module("google-maps.directives.api")
                 # Create the map
                 mapOptions = angular.extend({}, DEFAULTS, opts,
                   center: @getCoords(scope.center)
-                  draggable: @isTrue(attrs.draggable)
+                  draggable: @isTrue(scope.draggable)
                   zoom: scope.zoom
                   bounds: scope.bounds
                 )


### PR DESCRIPTION
As discusses in Issue #451 I added the `draggable´ option to the svope of the directive so its usable without double curly brackets.
