### PR TITLE
Create example of configuring a marker's anchor

### DIFF
--- a/example/assets/scripts/controllers/marker-anchor.js
+++ b/example/assets/scripts/controllers/marker-anchor.js
@@ -1,0 +1,31 @@
+// Code goes here
+
+angular.module('app', ['google-maps'])
+    .controller('mainCtrl', ['$scope', function($scope) {
+        $scope.number = 0;
+        $scope.map = {
+            center: {
+                latitude: 35.027469,
+                longitude: -111.022753
+            },
+            zoom: 4,
+            marker: {
+                id:0,
+                coords: {
+                    latitude: 35.027469,
+                    longitude: -111.022753
+                },
+                options: {
+                    icon: {
+                        anchor: new google.maps.Point(36,36),
+                        origin: new google.maps.Point(0,0),
+                        scaledSize: new google.maps.Size(72,72),
+                        url: 'assets/images/cluster1.png'
+                    }
+                }
+            }
+        };
+        $scope.click = function() {
+            $scope.number += 1;
+        }
+    }]);

--- a/example/marker-anchor.html
+++ b/example/marker-anchor.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html ng-app="app">
+
+<head>
+    <link rel="stylesheet" href="assets/stylesheets/example.css">
+    <script src="//maps.googleapis.com/maps/api/js?sensor=false"></script>
+    <script data-require="angular.js@1.2.x" src="https://code.angularjs.org/1.2.16/angular.js" data-semver="1.2.16"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.underscore.js"></script>
+    <script src="../dist/angular-google-maps.js"></script>
+    <script src="assets/scripts/controllers/marker-anchor.js"></script>
+    <title>Map</title>
+</head>
+
+<body ng-controller="mainCtrl">
+<button ng-click="click()"> +1 </button>
+<div id="map_canvas" >
+    <google-map center="map.center" zoom="map.zoom">
+        <marker coords="map.marker.coords" idkey="map.marker.id" options="map.marker.options"></marker>
+    </google-map>
+</div>
+{{number}}
+</body>
+
+</html>


### PR DESCRIPTION
The ability to configure a marker's anchor point using Google Maps is
less than intuitive. Although the documentation makes it sound like you
can configure it via a MarkerOptions object, that doesn't seem to work
with this library.  As such, you need to configure the anchor point on
the image itself.  This example demonstrates how to do that.
