### PR TITLE
Added a debug method in Logger service

### DIFF
--- a/dist/angular-google-maps.js
+++ b/dist/angular-google-maps.js
@@ -3934,6 +3934,15 @@ Nicholas McCready - https://twitter.com/nmccready
             }
           }
         },
+         debug:function(msg) {
+          if (this.doLog) {
+            if (this.logger != null) {
+              return this.logger.debug(msg);
+            } else {
+              return console.debug(msg);
+            }
+          }
+        },
         error: function(msg) {
           if (this.doLog) {
             if ($log != null) {


### PR DESCRIPTION
Without this, I am getting an  'undefined' is not a function (evaluating 'this.$log.debug(this)')  when using angular-google-maps within an application that implements $logProvider:  https://docs.angularjs.org/api/ng/service/$log
