### PR TITLE
Fix destroy on already destroyed scope (develop)

### DIFF
--- a/dist/angular-google-maps.js
+++ b/dist/angular-google-maps.js
@@ -2330,7 +2330,9 @@ Original idea from: http://stackoverflow.com/questions/22758950/google-map-drawi
             this.removeEvents(this.internalListeners);
             this.gMarkerManager.remove(this.gMarker, true);
             delete this.gMarker;
-            return this.scope.$destroy();
+            if (!this.scope.$$destroyed) {
+              return this.scope.$destroy();
+            }
           }
         };
 

--- a/src/coffee/directives/api/models/child/marker-child-model.coffee
+++ b/src/coffee/directives/api/models/child/marker-child-model.coffee
@@ -64,7 +64,8 @@ angular.module("google-maps.directives.api.models.child".ns())
             @removeEvents @internalListeners
             @gMarkerManager.remove @gMarker, true
             delete @gMarker
-            @scope.$destroy()
+            if !@scope.$$destroyed
+              @scope.$destroy()
 
         setCoords: (scope) =>
           if scope.$id != @scope.$id or @gMarker == undefined


### PR DESCRIPTION
It seems that when trying to destroy a lot of markers (and their scopes) at once, sometimes an already destroyed scope would get destroyed again, which obviously doesn't work. Simply wrapping the call in an if statement should be enough to fix this error
