### PR TITLE
Fixing mapControl directive when using full jQuery.

### DIFF
--- a/dist/angular-google-maps.js
+++ b/dist/angular-google-maps.js
@@ -4822,7 +4822,7 @@ Original idea from: http://stackoverflow.com/questions/22758950/google-map-drawi
                     });
                     controlDiv.children().data('$ngControllerController', templateCtrl);
                   }
-                  return control = $compile(controlDiv.contents())(templateScope);
+                  return control = $compile(controlDiv.children())(templateScope);
                 }).error(function(error) {
                   return _this.$log.error('mapControl: template could not be found');
                 }).then(function() {


### PR DESCRIPTION
Replacing controlDiv.contents() with controlDiv.children() in Control.prototype.link. jqLite appears to have a bug in that its .append() method doesn't behave exactly like jQuery's, resulting in an error when using the jQuery and the mapControl directive and when there's leading whitespace in the ng-template script tag (which is probably always the case).

For example, this causes an error:

```
<script type="text/ng-template" id="control.tpl.html">
  <button>control</button>
</script>
```

but this does not:

```
<script type="text/ng-template" id="control.tpl.html"><button>control</button></script>
```
