### PR TITLE
lazy update shouldn't change zoom level

### DIFF
--- a/dist/angular-google-maps.js
+++ b/dist/angular-google-maps.js
@@ -5541,7 +5541,6 @@ Original idea from: http://stackoverflow.com/questions/22758950/google-map-drawi
                       if (s.center.longitude !== c.lng()) {
                         s.center.longitude = c.lng();
                       }
-                      s.zoom = _m.zoom;
                     }
                   }
                   if (s.bounds !== null && s.bounds !== undefined && s.bounds !== void 0) {

--- a/src/coffee/directives/api/map.coffee
+++ b/src/coffee/directives/api/map.coffee
@@ -171,9 +171,6 @@ angular.module("uiGmapgoogle-maps.directives.api")
                     s.center.latitude = c.lat()  if s.center.latitude isnt c.lat()
                     s.center.longitude = c.lng()  if s.center.longitude isnt c.lng()
 
-                    # update zoom
-                    s.zoom = _m.zoom
-
                 if s.bounds isnt null and s.bounds isnt `undefined` and s.bounds isnt undefined
                   s.bounds.northeast =
                     latitude: ne.lat()


### PR DESCRIPTION
Upon more extensive testing I realized this is a bad
idea as it is causing the clusters to disappear when
zooming via click or mouse wheel. In fact setting zoom
here is completely unneeded. Tested this with clustering on
and off, its working great and providing a good boost in
performance.
