### PR TITLE
Add 'main' to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "directives",
     "webcomponent"
   ],
+  "main": "dist/angular-google-maps.js",
   "license": "MIT",
   "devDependencies": {
     "bower": "~1.3.12",


### PR DESCRIPTION
Adding a main section to the package.json for very simple browserify support. If the package is being pulled in using NPM (directly from the github repo as it is unpublished), this will allow browserify to find it.

Note this does not add proper module support, and references the non-minified file, assuming it will be part of a build process. The browser property could also be used instead if you prefer.

Full details: https://github.com/substack/node-browserify#packagejson
