### PR TITLE
Ensure map options are respected after free-drawing polygons

### DIFF
--- a/src/coffee/directives/api/free-draw-polygons.coffee
+++ b/src/coffee/directives/api/free-draw-polygons.coffee
@@ -20,7 +20,7 @@ angular.module('uiGmapgoogle-maps.directives.api')
         @mapPromise(scope, ctrl).then (map) =>
           return $log.error 'No polygons to bind to!' unless scope.polygons
           return $log.error 'Free Draw Polygons must be of type Array!' unless _.isArray scope.polygons
-          freeHand = new DrawFreeHandChildModel map
+          freeHand = new DrawFreeHandChildModel map, ctrl.getScope()
           listener = undefined
           scope.draw = ->
             #clear watch only watch when we are finished drawing/engaging

--- a/src/coffee/directives/api/models/child/free-draw-polygons-child.coffee
+++ b/src/coffee/directives/api/models/child/free-draw-polygons-child.coffee
@@ -27,30 +27,29 @@ angular.module('uiGmapgoogle-maps.directives.api.models.child')
 
     undefined
 
-  freeHandMgr = (@map) ->
-    disabledMapOptions =
-      draggable: false
-      disableDefaultUI: true
-      scrollwheel: false
-      disableDoubleClickZoom: false
-
-    enabledMapOptions =
-      draggable: true
-      disableDefaultUI: false
-      scrollwheel: true
-      disableDoubleClickZoom: true
-
+  freeHandMgr = (@map, scope) ->
     disableMap = =>
       # Whilst drawing, freeze the map (so that mouse "drag" action draws and doesn't move the map).
+      mapOptions =
+        draggable: false
+        disableDefaultUI: true
+        scrollwheel: false
+        disableDoubleClickZoom: false
+
       $log.info 'disabling map move'
-      @oldOptions = map.getOptions().options
-      @map.setOptions disabledMapOptions
+      @map.setOptions mapOptions
 
     enableMap = =>
       # After drawing, un-freeze the map.
+      mapOptions =
+        draggable: true
+        disableDefaultUI: false
+        scrollwheel: true
+        disableDoubleClickZoom: true
+
       @deferred?.resolve()
       _.defer =>
-        @map.setOptions _.defaults @oldOptions, enabledMapOptions
+        @map.setOptions _.extend mapOptions, scope.options
 
     @engage = (@polys) =>
       @deferred = $q.defer()


### PR DESCRIPTION
Resolves #952.

It's a bug fix, because there was already code in there to revert the map options after drawing, but it wasn't quite working the right way.

Changes:
- Use `@oldOptions = map.getOptions().options` instead of `@oldOptions = map.getOptions()`.
- Use `@map.setOptions _.defaults @oldOptions, enabledMapOptions` instead of `@map.setOptions _.extend @oldOptions, defaultOptions`.
