### PR TITLE
Fix for:  icons to be rendered along the polyline.

### DIFF
--- a/src/coffee/directives/api/options/builders/common-options-builder.coffee
+++ b/src/coffee/directives/api/options/builders/common-options-builder.coffee
@@ -38,7 +38,8 @@ angular.module('uiGmapgoogle-maps.directives.api.options.builders')
           static: false
           fit: false
           visible: true
-          zIndex: 0
+          zIndex: 0,
+          icons: []
       ), (defaultValue, key) =>
         val = @scopeOrModelVal key, @scope, model
         if angular.isUndefined val


### PR DESCRIPTION
Describes how icons are to be rendered on a line. 

If your polyline is geodesic, then the distances specified for both offset and repeat are calculated in meters by default. Setting either offset or repeat to a pixel value will cause the distances to be calculated in pixels on the screen.
