### PR TITLE
[Website # FAQ] Fix first tab reference

### DIFF
--- a/views/faq.html
+++ b/views/faq.html
@@ -20,7 +20,7 @@
 </ul>
 
 <div class="tab-content">
-    <div id="faq-map-instance-tab-html-js" class="tab-pane active">
+    <div id="faq-map-instance-tab-html" class="tab-pane active">
         <div hljs>
             <ui-gmap-google-map events="map.events"></ui-gmap-google-map>
         </div>


### PR DESCRIPTION
The tabs explaining the [first FAQ](http://angular-ui.github.io/angular-google-maps/#faq-map-instance) are not working due to an incorrect DOM reference.
