### PR TITLE
1075 - patch for getting the icon model property

### DIFF
--- a/example/assets/scripts/controllers/issue-1075-markers-icon-change.js
+++ b/example/assets/scripts/controllers/issue-1075-markers-icon-change.js
@@ -1,0 +1,73 @@
+angular.module('appMaps', ['uiGmapgoogle-maps'])
+    .controller('mapIconChangeCtrl', mapController);
+
+mapController.$inject = ['uiGmapGoogleMapApi'];
+
+function mapController(GoogleMapApi) {
+    GoogleMapApi.then(function(maps) {
+        maps.visualRefresh=true
+    });
+
+    var viewmodel = this;
+
+    var blueicon = 'http://maps.google.com/mapfiles/ms/icons/blue-dot.png';
+    var redicon = 'http://maps.google.com/mapfiles/ms/icons/red-dot.png';
+    var testlocation = {
+        id: 'abc123',
+        name: 'CN Tower',
+        latitude: 43.642496,
+        longitude: -79.386954
+    }
+
+    viewmodel.changeIcon = changeIcon;
+    viewmodel.changeObject = changeObject;
+
+    viewmodel.markerControl = {}
+
+    viewmodel.map = {
+        center: {
+            latitude: 43.642496,
+            longitude: -79.386954
+        },
+        zoom: 12,
+        markers: [
+            {
+                location: testlocation,
+                id: 'abc123',
+                icon: 'http://maps.google.com/mapfiles/ms/icons/blue-dot.png'
+            }
+        ]
+    };
+
+    function changeIcon() {
+        var newicon = redicon;
+        if (viewmodel.map.markers[0].icon === redicon) {
+            newicon = blueicon;
+        }
+
+        console.log('changing the icon property from ' +
+        viewmodel.map.markers[0].icon + ' to ' + newicon);
+
+        viewmodel.map.markers[0].icon = newicon;
+    }
+
+    function changeObject() {
+        var newicon = redicon;
+        if (viewmodel.map.markers[0].icon === redicon) {
+            newicon = blueicon;
+        }
+
+        var newMarker = {
+            location: testlocation,
+            id: 'abc123',
+            icon: newicon
+        };
+
+        console.log('changing the marker object from one with icon ' +
+        viewmodel.map.markers[0].icon + ' to an object with icon ' + newicon);
+        var childMarker = viewmodel.markerControl.getChildMarkers().get('abc123')
+        childMarker.updateModel(newMarker)
+        viewmodel.map.markers[0] = childMarker.model
+
+    }
+}

--- a/example/issue-1075-markers-icon-change.html
+++ b/example/issue-1075-markers-icon-change.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="assets/stylesheets/example.css"/>
+    <script src="../bower_components/angular/angular.js"></script>
+    <script src="../bower_components/angular-route/angular-route.js"></script>
+    <script src="../bower_components/lodash/dist/lodash.js"></script>
+    <script src="../dist/angular-google-maps_dev_mapped.js"></script>
+    <script src="assets/scripts/controllers/issue-1075-markers-icon-change.js"></script>
+</head>
+<body ng-app="appMaps">
+<div ng-controller="mapIconChangeCtrl as mapvm">
+    <button ng-click="mapvm.changeIcon()">Update Icon property</button>
+    <button ng-click=mapvm.changeObject()>Replace Marker object</button>
+    <ui-gmap-google-map
+            center='mapvm.map.center'
+            zoom='mapvm.map.zoom'>
+
+        <ui-gmap-markers
+                models="mapvm.map.markers"
+                coords="'location'"
+                icon="'icon'"
+                control="mapvm.markerControl"
+                modelsByRef="true"
+                ></ui-gmap-markers>
+
+    </ui-gmap-google-map>
+</div>
+</body>
+</html>

--- a/src/coffee/directives/api/models/child/marker-child-model.coffee
+++ b/src/coffee/directives/api/models/child/marker-child-model.coffee
@@ -145,10 +145,10 @@ angular.module('uiGmapgoogle-maps.directives.api.models.child')
         return if @isNotValid(scope) or !@gObject?
         @renderGMarker doDraw, =>
           oldValue = @gObject.getIcon()
-          newValue = @getProp 'icon', @model
+          newValue = @getProp 'icon',scope, @model
           return if  oldValue == newValue
           @gObject.setIcon newValue
-          coords = @getProp 'coords', @model
+          coords = @getProp 'coords', scope, @model
           @gObject.setPosition @getCoords coords
           @gObject.setVisible @validateCoords coords
 


### PR DESCRIPTION
I was getting this error when using the new plural code:
```
TypeError: Cannot read property 'http://maps.google.com/mapfiles/ms/icons/blue-dot.png' of undefined
    at MarkerChildModel.angular.module.factory.ModelKey.scopeOrModelVal (http://localhost:3100/dist/angular-google-maps_dev_mapped.js:1396:60)
    at MarkerChildModel.angular.module.factory.ModelKey.getProp (http://localhost:3100/dist/angular-google-maps_dev_mapped.js:1328:23)
    at MarkerChildModel.__bind [as getProp] (http://localhost:3100/dist/angular-google-maps_dev_mapped.js:1265:63)
    at http://localhost:3100/dist/angular-google-maps_dev_mapped.js:3164:32
    at MarkerChildModel.angular.module.factory.MarkerChildModel.renderGMarker (http://localhost:3100/dist/angular-google-maps_dev_mapped.js:3040:15)
    at MarkerChildModel.angular.module.factory.MarkerChildModel.setIcon (http://localhost:3100/dist/angular-google-maps_dev_mapped.js:3160:23)
    at __bind (http://localhost:3100/dist/angular-google-maps_dev_mapped.js:2889:63)
    at MarkerChildModel.angular.module.factory.MarkerChildModel.maybeSetScopeValue (http://localhost:3100/dist/angular-google-maps_dev_mapped.js:3112:13)
    at MarkerChildModel.__bind [as maybeSetScopeValue] (http://localhost:3100/dist/angular-google-maps_dev_mapped.js:2889:63)
    at MarkerChildModel.angular.module.factory.MarkerChildModel.setMyScope (http://localhost:3100/dist/angular-google-maps_dev_mapped.js:3080:27)
```
So, I added the `scope` back into the `getProp` call and that got things back to where they were. I added an issue as an example to play around with.  You can toggle the icon property and you can toggle the marker object. But once you toggle the marker object you can no longer toggle the icon property. I was still looking into why that was. It appears to be an issue when replacing the model object in the collection, once that happens the replacement is not longer binding properly.