### PR TITLE
Update curl.json - for latest infobox.js source

### DIFF
--- a/curl.json
+++ b/curl.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "gmap-util-keydragzoom": "http://google-maps-utility-library-v3.googlecode.com/svn/tags/keydragzoom/2.0.9/src/keydragzoom.js",
-    "gmap-util-infobox": "http://google-maps-utility-library-v3.googlecode.com/svn/tags/infobox/1.1.12/src/infobox.js",
+    "gmap-util-infobox": "http://google-maps-utility-library-v3.googlecode.com/svn/tags/infobox/1.1.13/src/infobox.js",
     "gmap-util-markerclustererplus": "http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerclustererplus/2.1.1/src/markerclusterer.js",
     "gmap-util-markerwithlabel": "http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerwithlabel/1.1.9/src/markerwithlabel.js"
   }


### PR DESCRIPTION
latest version of infobox (1.1.13) which fixes this iOS issue :
http://stackoverflow.com/questions/9229535/google-maps-markers-disappear-at-certain-zoom-level-only-on-iphone-ipad

source diff:
https://code.google.com/p/google-maps-utility-library-v3/source/diff?spec=svn466&r=466&format=side&path=/trunk/infobox/src/infobox.js