### PR TITLE
Update curl.json - for latest markerwithlabel.js source

### DIFF
--- a/curl.json
+++ b/curl.json
@@ -3,6 +3,6 @@
     "gmap-util-keydragzoom": "http://google-maps-utility-library-v3.googlecode.com/svn/tags/keydragzoom/2.0.9/src/keydragzoom.js",
     "gmap-util-infobox": "http://google-maps-utility-library-v3.googlecode.com/svn/tags/infobox/1.1.12/src/infobox.js",
     "gmap-util-markerclustererplus": "http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerclustererplus/2.1.1/src/markerclusterer.js",
-    "gmap-util-markerwithlabel": "http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerwithlabel/1.1.9/src/markerwithlabel.js"
+    "gmap-util-markerwithlabel": "http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerwithlabel/1.1.10/src/markerwithlabel.js"
   }
 }


### PR DESCRIPTION
MarkerWithLabel 1.1.10: Fix for forgetting to clean up invisible click nodes when changing label content.

source: 
http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerwithlabel/1.1.10/src/markerwithlabel.js

source diff : 
https://code.google.com/p/google-maps-utility-library-v3/source/diff?spec=svn473&r=468&format=side&path=/trunk/markerwithlabel/src/markerwithlabel.js&old_path=/trunk/markerwithlabel/src/markerwithlabel.js&old=464