### PR TITLE
Fixing some undefined variables bugs #1161 and #1162

### DIFF
--- a/src/coffee/directives/api/managers/clusterer-marker-manager.coffee
+++ b/src/coffee/directives/api/managers/clusterer-marker-manager.coffee
@@ -19,7 +19,7 @@ angular.module('uiGmapgoogle-maps.directives.api.managers')
     checkKey: (gMarker) ->
       unless gMarker.key?
         msg = 'gMarker.key undefined and it is REQUIRED!!'
-        Logger.error msg
+        $log.error msg
 
     add: (gMarker)=>
       @checkKey gMarker
@@ -63,7 +63,7 @@ angular.module('uiGmapgoogle-maps.directives.api.managers')
             $log.info "#{optionsName}: Attaching event: #{eventName} to clusterer"
             google.maps.event.addListener @clusterer, eventName, options[eventName]
 
-    clearEvents: (options) ->
+    clearEvents: (options, optionsName) ->
       if angular.isDefined(options) and options? and angular.isObject(options)
         for eventName, eventHandler of options
           if options.hasOwnProperty(eventName) and angular.isFunction(options[eventName])
@@ -71,8 +71,7 @@ angular.module('uiGmapgoogle-maps.directives.api.managers')
             google.maps.event.clearListeners @clusterer, eventName
 
     destroy: =>
-      @clearEvents @opt_events
-      @clearEvents @opt_internal_events
+      @clearEvents @opt_events, 'opt_events'
       @clear()
 
     fit: =>

--- a/src/coffee/directives/api/models/parent/rectangle-parent-model.coffee
+++ b/src/coffee/directives/api/models/parent/rectangle-parent-model.coffee
@@ -22,8 +22,8 @@ angular.module('uiGmapgoogle-maps.directives.api.models.parent')
         else if scope.bounds.getNorthEast? and scope.bounds.getSouthWest? #google format
             bounds = scope.bounds
         else
-          if bound?
-            $log.error "Invalid bounds for newValue: #{JSON.stringify scope.bounds}" #note if bouds is recursive this could crash
+          if scope.bounds?
+            $log.error "Invalid bounds for newValue: #{JSON.stringify scope.bounds}" #note if bounds is recursive this could crash
       createBounds()
       gObject = new google.maps.Rectangle(@buildOpts bounds)
       $log.info "gObject (rectangle) created: #{gObject}"


### PR DESCRIPTION
Fixes as I understand it should be.

The `opt_internal_events` identifier is used only once, so IMHO that line can be removed.