### PR TITLE
(chore): Add packaging for Meteor.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ _SpecRunner.html
 /curl_components
 .tmp
 /app
+
+# Meteor package creation files
+.versions

--- a/README.markdown
+++ b/README.markdown
@@ -59,6 +59,12 @@ If you plan to hack on the directives or want to run the example, first thing to
 npm install #note bower install is run on post install 
 ```
 
+* Installing for [Meteor](https://www.meteor.com/) application:
+
+```shell
+meteor add angularui:angular-google-maps
+```
+
 ### Building
 To build the library after you made changes, simply run grunt:
 

--- a/package.js
+++ b/package.js
@@ -1,0 +1,23 @@
+// package metadata file for Meteor.js
+var packageName = 'angularui:angular-google-maps'; // https://atmospherejs.com/angularui/angular-google-maps
+var where = 'client'; // where to install: 'client' or 'server'. For both, pass nothing.
+var version = '2.0.12';
+
+Package.describe({
+  name: packageName,
+  version: version,
+  summary: 'angular-google-maps (official)',
+  git: 'git@github.com:angular-ui/angular-google-maps.git',
+  documentation: null
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+
+  api.use([
+    'angularjs:angular@1.2.0',
+    'stevezhu:lodash@1.0.2'
+  ], where);
+
+  api.addFiles('dist/angular-google-maps.js', where);
+});


### PR DESCRIPTION
Hi @nmccready

I'm a package maintainer for Meteor.js, a popular [full-stack JavaScript framework](https://www.meteor.com/).

I'm also the creator of [angular-meteor](http://angularjs.meteor.com/), a library that let's you work with AngularJS on top of Meteor.

A lot of our users use angular-google-maps and right now there is a separate package and Github repo that simply manually copies your distribution and publish it to Meteor.

There is also a [tutorial about working with Meteor, AngularJS and angular-google-maps](http://angularjs.meteor.com/tutorial-02/step_16).

This PR is a start to allow you to directly publish updated versions of angular-google-maps to Meteor as they become available. 
All you have to do is create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and I'll add you as a maintainer to the angularui organization there.

I've already published the current version of the package on Atmosphere (Meteor's package directory). When you release new versions of angular-google-maps, you'll be able to publish them to Atmosphere by running 

    meteor publish

There are also prepared grunt tasks for that but I wanted you to try to put them yourself as they are not in coffeescript.

Thanks & best regards,
Uri