### PR TITLE
Remove post-install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "build": "grunt",
     "example": "grunt example",
-    "test": "grunt",
-    "postinstall": "bower install && grunt curl"
+    "test": "grunt"
   },
   "keywords": [
     "angularjs",


### PR DESCRIPTION
It should not be done in post-install because these actions should only be done in development.