### PR TITLE
Change in service source code links

### DIFF
--- a/app/views/service/Async.html
+++ b/app/views/service/Async.html
@@ -1,5 +1,5 @@
 <div class="uiGmap_async uigmap-api">
-  <a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/directives/api/utils/_async.coffee">Service (Source Code)</a> is primarily used to provide chunked asynchronous iterators.
+  <a href="https://github.com/angular-ui/angular-google-maps/blob/master/src/coffee/directives/api/utils/_async.coffee">Service (Source Code)</a> is primarily used to provide chunked asynchronous iterators.
 <br/><br/>
 <table class="table table-bordered table-striped">
       <tr>

--- a/app/views/service/IsReady.html
+++ b/app/views/service/IsReady.html
@@ -13,7 +13,7 @@ Beyond that, the instances passed back to you come back with the following info:
     </li>
 </ul>
 
-<a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/directives/api/utils/is-ready.coffee">source code</a>
+<a href="https://github.com/angular-ui/angular-google-maps/blob/master/src/coffee/directives/api/utils/is-ready.coffee">source code</a>
 
 <div hljs language="js">
 .controller("someController", function(uiGmapIsReady) {

--- a/app/views/service/Logger.html
+++ b/app/views/service/Logger.html
@@ -1,7 +1,7 @@
 This logger utilizes $log underneath. The API now logs errors by default with the logger enabled.
 Therefore the default <code>currentLevel</code> is "error".
 <br>
-<a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/directives/api/utils/logger.coffee">source code</a>
+<a href="https://github.com/angular-ui/angular-google-maps/blob/master/src/coffee/directives/api/utils/logger.coffee">source code</a>
 
 <div hljs language="js">
 .controller("someController", function(uiGmapLogger) {

--- a/app/views/service/Promise.html
+++ b/app/views/service/Promise.html
@@ -2,7 +2,7 @@
 Service is a utility to aid in Angular $q promises. It is primarily used for its extensions of
 <code>ExposedPromise</code> and <code>SniffedPromise</code> by <a ui-sref="api.Async" href="#!/api">uiGmap_Async</a>.
 <br/><br/>
-<a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/directives/api/utils/promise.coffee">source code</a>
+<a href="https://github.com/angular-ui/angular-google-maps/blob/master/src/coffee/directives/api/utils/promise.coffee">source code</a>
 
 <table class="table table-bordered table-striped">
       <tr>


### PR DESCRIPTION
There were an errors in links on service pages that lead to the source code on github. I changed links to master page instead develop which was resulting an 404 error.