### PR TITLE
typo in call to uiGmapObjectIterators.slapAll

### DIFF
--- a/example/assets/scripts/controllers/markers-models-objects.js
+++ b/example/assets/scripts/controllers/markers-models-objects.js
@@ -65,7 +65,7 @@ angular.module('appMaps', ['uiGmapgoogle-maps'])
         lastId = 1;//reset
         markers.length = num;
 
-        $scope.searchResults.results = uiGmapObjectIterators.slappAll(markers);
+        $scope.searchResults.results = uiGmapObjectIterators.slapAll(markers);
       };
 
       $scope.reset = function () {


### PR DESCRIPTION
'Uncaught TypeError: undefined is not a function' when attempting to load markers-models-objects example.