### PR TITLE
fix(markerLabel): don't reset the anchor on change

### DIFF
--- a/src/coffee/directives/api/models/child/marker-child-model.coffee
+++ b/src/coffee/directives/api/models/child/marker-child-model.coffee
@@ -196,7 +196,7 @@ angular.module('uiGmapgoogle-maps.directives.api.models.child')
           @gManager.fit()
 
       setLabelOptions: (opts) =>
-        opts.labelAnchor = @getLabelPositionPoint opts.labelAnchor
+        opts.labelAnchor = @getLabelPositionPoint opts.labelAnchor if opts.labelAnchor
         opts
 
       internalEvents: =>


### PR DESCRIPTION
When the marker has a label without "labelAnchor" specified and the position changes, "labelAnchor" is reset from the default (a Point at 0,0) to undefined. This is because the default is set only when the marker label is created. As a result of this, MarkerLabel.setAnchor throws an error trying to access the "x" property on the undefined anchor.

This PR will prevent the default from being overwritten and these exceptions from being thrown (which also causes the map to lock up).