### PR TITLE
replaced _.extend calls by _.clone calls

### DIFF
--- a/src/coffee/directives/api/models/child/marker-child-model.coffee
+++ b/src/coffee/directives/api/models/child/marker-child-model.coffee
@@ -23,7 +23,7 @@ angular.module('uiGmapgoogle-maps.directives.api.models.child')
         @trackModel = true, @needRedraw = false) ->
         #where @model is a reference to model in the controller scope
         #clonedModel is a copy for comparison
-        @clonedModel = _.extend({},@model)
+        @clonedModel = _.clone(@model,true)
         @deferred = uiGmapPromise.defer()
         _.each @keys, (v, k) =>
           keyValue = @keys[k]
@@ -80,7 +80,7 @@ angular.module('uiGmapgoogle-maps.directives.api.models.child')
             @needRedraw = true
 
       updateModel: (model) =>
-        @clonedModel = _.extend({},model) #changed from _.clone(model, true) eliminates lodash dep (so you can use underscore)
+        @clonedModel = _.clone(model,true) #changed from _.clone(model, true) eliminates lodash dep (so you can use underscore)
         @setMyScope 'all', model, @model
 
       renderGMarker: (doDraw = true, validCb) ->

--- a/src/coffee/directives/api/models/child/window-child-model.coffee
+++ b/src/coffee/directives/api/models/child/window-child-model.coffee
@@ -199,7 +199,7 @@ angular.module('uiGmapgoogle-maps.directives.api.models.child')
             @scope.$destroy()
 
         updateModel: (model) =>
-          @clonedModel = _.extend({},model)
+          @clonedModel = _.clone(model,true)
           _.extend(@model, @clonedModel)
 
       WindowChildModel


### PR DESCRIPTION
solves issue #1350

See https://github.com/angular-ui/angular-google-maps/issues/1350
for a discussion on lodash dependency and ways to get rid of it.