### PR TITLE
GoogleMapApi and IsReady descriptions are explicit about usage re control object augmentation

### DIFF
--- a/app/views/provider/GoogleMapApi.html
+++ b/app/views/provider/GoogleMapApi.html
@@ -8,6 +8,12 @@ This provider is was created for a few reasons:
         It guarantees that angular-google-maps does not begin processing any directives until all of the Google Maps SDK is fully ready!
     </li>
 </ul>
+
+<div class="alert alert-info">
+  <code>uiGmapGoogleMapApi</code> (<em>this service</em>) should not be used to wait for directives to finish
+  augmenting <code>control</code> objects. The <code>uiGmapIsReady</code> service should be used instead.
+</div>
+
 To utilize this provider you must load it and configure it properly. Please note the
 <a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/providers/map-loader.coffee#L31-L50">defaults</a>!
 

--- a/app/views/service/IsReady.html
+++ b/app/views/service/IsReady.html
@@ -13,6 +13,11 @@ Beyond that, the instances passed back to you come back with the following info:
     </li>
 </ul>
 
+<div class="alert alert-info">
+  The <code>uiGmapGoogleMapApi</code> service should not be used to wait for directives to finish
+  augmenting <code>control</code> objects. <code>uiGmapIsReady</code> (<em>this service</em>) should be used instead.
+</div>
+
 <a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/directives/api/utils/is-ready.coffee">source code</a>
 
 <div hljs language="js">


### PR DESCRIPTION
Attempting to resolve #1343. Seems like a minor change, but feedback definitely welcome.