### PR TITLE
updated links to source code and ordered parameters - mandatory first

### DIFF
--- a/app/views/directive/google-map.html
+++ b/app/views/directive/google-map.html
@@ -50,6 +50,13 @@
         </td>
     </tr>
     <tr>
+        <td>zoom</td>
+        <td><span class="label label-danger">expression</span></td>
+        <td>Expression to evaluate as the map's zoom level. This must be a number between 1<sup>[1]</sup> and
+            20<sup>[2]</sup>.
+        </td>
+    </tr>
+    <tr>
         <td>control</td>
         <td><span class="label label-default">Object</span></td>
         <td><code>{}</code> otherwise <code>undefined / null </code>
@@ -73,13 +80,6 @@
 
             <p>example</p>
             <code>$scope.map.control.refresh({latitude: 32.779680, longitude: -79.935493});</code>
-        </td>
-    </tr>
-    <tr>
-        <td>zoom</td>
-        <td><span class="label label-danger">expression</span></td>
-        <td>Expression to evaluate as the map's zoom level. This must be a number between 1<sup>[1]</sup> and
-            20<sup>[2]</sup>.
         </td>
     </tr>
     <tr>

--- a/app/views/directive/markers.html
+++ b/app/views/directive/markers.html
@@ -58,6 +58,17 @@
             </td>
         </tr>
         <tr>
+            <td>coords</td>
+            <td><span class="label label-danger">string</span></td>
+            <td>
+                <p>The name of the property in the models array containing the marker coordinates. Must refer to an
+                    object
+                    containing <code>latitude</code> and <code>longitude</code> properties, or  a <a
+                            href="http://geojson.org/geojson-spec.html#point">GeoJSON Point</a> object.</p>
+                <span>The special value <code>'self'</code> can be used to tell the directive that the objects in the array directly contain the marker coordinate object values</span>
+            </td>
+        </tr>
+        <tr>
             <td>idkey</td>
             <td><span class="label label-info">expression</span></td>
             <td>
@@ -121,17 +132,6 @@ $scope.clickEventsObject =
             <td>fit</td>
             <td><span class="label label-info">string / boolean</span></td>
             <td>boolean property to instruct the map to fit its bounds around the markers</td>
-        </tr>
-        <tr>
-            <td>coords</td>
-            <td><span class="label label-danger">string</span></td>
-            <td>
-                <p>The name of the property in the models array containing the marker coordinates. Must refer to an
-                    object
-                    containing <code>latitude</code> and <code>longitude</code> properties, or  a <a
-                            href="http://geojson.org/geojson-spec.html#point">GeoJSON Point</a> object.</p>
-                <span>The special value <code>'self'</code> can be used to tell the directive that the objects in the array directly contain the marker coordinate object values</span>
-            </td>
         </tr>
         <tr>
             <td>icon</td>

--- a/app/views/directive/partials/polys.html
+++ b/app/views/directive/partials/polys.html
@@ -41,15 +41,6 @@
         </td>
     </tr>
     <tr>
-        <td>idkey</td>
-        <td><span class="label label-info">expression</span></td>
-        <td>
-            <p>The name of the property in a model which identifies its key/id. This should be an integer
-                or numeric string. (not required) If the attribute is not defined they it defaults to the
-                <code>model.id</code> field.</p>
-        </td>
-    </tr>
-    <tr>
         <td>path</td>
         <td><span class="label label-danger">string</span></td>
         <td>
@@ -60,6 +51,15 @@
                         href="https://developers.google.com/maps/documentation/javascript/reference#LatLng">Google Maps
                     LatLng</a> objects. Alternatively, a <a
                         href="http://geojson.org/geojson-spec.html#linestring">GeoJSON LineString</a> object.</p>
+        </td>
+    </tr>
+    <tr>
+        <td>idkey</td>
+        <td><span class="label label-info">expression</span></td>
+        <td>
+            <p>The name of the property in a model which identifies its key/id. This should be an integer
+                or numeric string. (not required) If the attribute is not defined they it defaults to the
+                <code>model.id</code> field.</p>
         </td>
     </tr>
     <tr>

--- a/app/views/directive/polygon.html
+++ b/app/views/directive/polygon.html
@@ -71,14 +71,14 @@
             <td>boolean property to make the polyline follow the curvature of the earth</td>
         </tr>
         <tr>
-            <td>icons</td>
-            <td><span class="label label-info">expression</span></td>
-            <td>TODO</td>
-        </tr>
-        <tr>
             <td>visible</td>
             <td><span class="label label-info">expression</span></td>
             <td>boolean property which shows or hides the polygon</td>
+        </tr>
+        <tr>
+            <td>fit</td>
+            <td><span class="label label-info">string or boolean</span></td>
+            <td>boolean property to instruct the map to fit its bounds around the {{thing}}</td>
         </tr>
         <tr>
             <td>zindex</td>

--- a/app/views/directive/windows.html
+++ b/app/views/directive/windows.html
@@ -64,22 +64,6 @@
             </td>
         </tr>
         <tr>
-            <td>idkey</td>
-            <td><span class="label label-info">expression</span></td>
-            <td>
-                <p>The name of the property in a model which identifies its key/id. This should be an integer
-                    or numeric string. (not required) If the attribute is not defined they it defaults to the <code>model.id</code>
-                    field.</p>
-            </td>
-        </tr>
-        <tr>
-            <td>doRebuildAll</td>
-            <td><span class="label label-info">expression</span></td>
-            <td>boolean property to tell the directive to refresh all the markers on any kind change to models. (Think
-                legacy "flash"). Yes sometimes this is wanted.
-            </td>
-        </tr>
-        <tr>
             <td>coords</td>
             <td><span class="label label-danger">string</span></td>
             <td>
@@ -127,6 +111,22 @@
             <td>closeClick</td>
             <td><span class="label label-danger">string</span></td>
             <td>The name of the property in the models array to evaluate when closing the window via a click event</td>
+        </tr>
+        <tr>
+            <td>idkey</td>
+            <td><span class="label label-info">expression</span></td>
+            <td>
+                <p>The name of the property in a model which identifies its key/id. This should be an integer
+                    or numeric string. (not required) If the attribute is not defined they it defaults to the <code>model.id</code>
+                    field.</p>
+            </td>
+        </tr>
+        <tr>
+            <td>doRebuildAll</td>
+            <td><span class="label label-info">expression</span></td>
+            <td>boolean property to tell the directive to refresh all the markers on any kind change to models. (Think
+                legacy "flash"). Yes sometimes this is wanted.
+            </td>
         </tr>
         <tr ng-include="'./views/directive/partials/options.html'" ng-init="thing='InfoWindow';directive='Windows';isStringTypeOnArray=true">
         </tbody>

--- a/app/views/provider/GoogleMapApi.html
+++ b/app/views/provider/GoogleMapApi.html
@@ -15,7 +15,7 @@ This provider is was created for a few reasons:
 </div>
 
 To utilize this provider you must load it and configure it properly. Please note the
-<a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/providers/map-loader.coffee#L31-L50">defaults</a>!
+<a href="https://github.com/angular-ui/angular-google-maps/blob/master/src/coffee/providers/map-loader.coffee#L31-L50">defaults</a>!
 
 <h3> Configure</h3>
 <div hljs language="js">

--- a/app/views/service/Async.html
+++ b/app/views/service/Async.html
@@ -1,5 +1,5 @@
 <div class="uiGmap_async uigmap-api">
-  <a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/directives/api/utils/_async.coffee">Service (Source Code)</a> is primarily used to provide chunked asynchronous iterators.
+  <a href="https://github.com/angular-ui/angular-google-maps/blob/master/src/coffee/directives/api/utils/_async.coffee">Service (Source Code)</a> is primarily used to provide chunked asynchronous iterators.
 <br/><br/>
 <table class="table table-bordered table-striped">
       <tr>

--- a/app/views/service/IsReady.html
+++ b/app/views/service/IsReady.html
@@ -18,7 +18,7 @@ Beyond that, the instances passed back to you come back with the following info:
   augmenting <code>control</code> objects. <code>uiGmapIsReady</code> (<em>this service</em>) should be used instead.
 </div>
 
-<a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/directives/api/utils/is-ready.coffee">source code</a>
+<a href="https://github.com/angular-ui/angular-google-maps/blob/master/src/coffee/directives/api/utils/is-ready.coffee">source code</a>
 
 <div hljs language="js">
 .controller("someController", function(uiGmapIsReady) {

--- a/app/views/service/Logger.html
+++ b/app/views/service/Logger.html
@@ -1,7 +1,7 @@
 This logger utilizes $log underneath. The API now logs errors by default with the logger enabled.
 Therefore the default <code>currentLevel</code> is "error".
 <br>
-<a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/directives/api/utils/logger.coffee">source code</a>
+<a href="https://github.com/angular-ui/angular-google-maps/blob/master/src/coffee/directives/api/utils/logger.coffee">source code</a>
 
 <div hljs language="js">
 .controller("someController", function(uiGmapLogger) {

--- a/app/views/service/Promise.html
+++ b/app/views/service/Promise.html
@@ -2,7 +2,7 @@
 Service is a utility to aid in Angular $q promises. It is primarily used for its extensions of
 <code>ExposedPromise</code> and <code>SniffedPromise</code> by <a ui-sref="api.Async" href="#!/api">uiGmap_Async</a>.
 <br/><br/>
-<a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/directives/api/utils/promise.coffee">source code</a>
+<a href="https://github.com/angular-ui/angular-google-maps/blob/master/src/coffee/directives/api/utils/promise.coffee">source code</a>
 
 <table class="table table-bordered table-striped">
       <tr>

--- a/app/views/service/PropMap.html
+++ b/app/views/service/PropMap.html
@@ -1,6 +1,6 @@
 <div class="uiGmapPropMap uigmap-api">
   Hashmap/Dictionary/KVP which caches it's state when being converted to an Array.
-  <a href="https://github.com/angular-ui/angular-google-maps/blob/develop/src/coffee/directives/api/utils/prop-map.coffee">Service (Source Code)</a>.
+  <a href="https://github.com/angular-ui/angular-google-maps/blob/master/src/coffee/directives/api/utils/prop-map.coffee">Service (Source Code)</a>.
 <br/><br/>
 <table class="table table-bordered table-striped">
       <tr>


### PR DESCRIPTION
The links to source code were broken since they referenced `develop` branch which is not around anymore.

I also took the time to update the directives parameters section so now the required properties are first.