### PR TITLE
Resets _currentCheckNum in uiGmapIsReady.promise

### DIFF
--- a/src/coffee/directives/api/utils/is-ready.coffee
+++ b/src/coffee/directives/api/utils/is-ready.coffee
@@ -34,6 +34,7 @@ angular.module('uiGmapgoogle-maps.directives.api.utils')
     _ctr
 
   promise: (expectedInstances = 1) ->
+    _currentCheckNum = 1
     d = $q.defer()
     _checkIfReady(d, expectedInstances)
     d.promise


### PR DESCRIPTION
I was getting 'Your maps are not found we have checked the maximum amount of times. :)' after some destroy and recreating of map controls.