### PR TITLE
Allow path-like strings to specify nested properties

### DIFF
--- a/src/coffee/directives/api/utils/model-key.coffee
+++ b/src/coffee/directives/api/utils/model-key.coffee
@@ -94,7 +94,7 @@ angular.module('uiGmapgoogle-maps.directives.api.utils')
           if doWrap
             return {isScope: isScope, value: ret}
           ret
-        scopeProp = scope[key]
+        scopeProp = _.get scope, key
 
         if _.isFunction scopeProp
           return maybeWrap true, scopeProp(model), doWrap
@@ -105,9 +105,9 @@ angular.module('uiGmapgoogle-maps.directives.api.utils')
 
         modelKey = scopeProp #this should be the key pointing to what we need
         unless modelKey
-          modelProp = model[key]
+          modelProp = _.get model, key
         else
-          modelProp = if modelKey == 'self' then model else model[modelKey]
+          modelProp = if modelKey == 'self' then model else _.get model, modelKey
         if _.isFunction modelProp
           return maybeWrap false, modelProp(), doWrap
         maybeWrap false, modelProp, doWrap


### PR DESCRIPTION
Attempting to resolve #1385 by using `_.get` in `ModelKey.scopeOrModelVal`.

Verified to work against [MCVE at #1385](http://plnkr.co/edit/8mqemGQ3jJsJGd32sPfS?p=preview), and our main example template seems to run with all functionality and with no console errors.

Unless `_.get` is already used elsewhere in the source, this introduces a dependency on [lodash 3.7.0+](https://github.com/lodash/lodash/wiki/Changelog#v370).