### PR TITLE
upgrade to using latest lodash

### DIFF
--- a/package.js
+++ b/package.js
@@ -18,7 +18,7 @@ Package.onUse(function(api) {
   api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
 
   api.use([
-    'stevezhu:lodash@1.0.2',
+    'stevezhu:lodash@3.10.1',
     'angular:angular@1.2.0',
     'nmccready:angular-simple-logger@0.0.1'
   ], where);

--- a/package.js
+++ b/package.js
@@ -18,7 +18,7 @@ Package.onUse(function(api) {
   api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
 
   api.use([
-    'stevezhu:lodash@3.10.1',
+    'stevezhu:lodash@3.0.0',
     'angular:angular@1.2.0',
     'nmccready:angular-simple-logger@0.0.1'
   ], where);


### PR DESCRIPTION
The node version requires a minimum of 3.8, lets let the meteor version use the latest lodash as well. This will fix problem in my project where I can't use lodash version newer than 1 if I include this package.