### PR TITLE
Replace remove() with removeChild() to delete an existing script tag

### DIFF
--- a/src/coffee/providers/map-loader.coffee
+++ b/src/coffee/providers/map-loader.coffee
@@ -23,7 +23,10 @@ angular.module('uiGmapgoogle-maps.providers')
         query = _.map _.omit(options, omitOptions), (v, k) ->
           k + '=' + v
 
-        document.getElementById(scriptId).remove() if scriptId
+        if scriptId
+          scriptElem = document.getElementById(scriptId)
+          scriptElem.parentNode.removeChild(scriptElem)
+
         query = query.join '&'
         script = document.createElement 'script'
         script.id = scriptId = "ui_gmap_map_load_#{uuid.generate()}"


### PR DESCRIPTION
This fixes an error raised when a script tag for Gmaps API is already in the document.

See issue https://github.com/angular-ui/angular-google-maps/issues/1521