### PR TITLE
Use correct markers.click arguments

### DIFF
--- a/app/views/examples/windows/script.js
+++ b/app/views/examples/windows/script.js
@@ -23,7 +23,7 @@ angular.module('appMaps', ['uiGmapgoogle-maps'])
             ret[idKey] = i;
             return ret;
         };
-        $scope.onClick = function(model) {
+        $scope.onClick = function(marker, eventName, model) {
             console.log("Clicked!");
             model.show = !model.show;
         };


### PR DESCRIPTION
Toggling an InfoWindow didn't work because $scope.onClick receives the marker object, not the model as the first argument.

After this change one can toggle an InfoWindow by clicking on a marker, but there is still a problem somewhere, because it stops working if I change the 'show' key to anything else: http://plnkr.co/edit/Je2yTpbBZ1aEEpga8les?p=preview