### PR TITLE
Updated internal links on `marker-label` api page

### DIFF
--- a/views/directive/marker-label.html
+++ b/views/directive/marker-label.html
@@ -2,7 +2,7 @@
  <span class="label label-danger">OBSOLETE / REMOVED</span>
  <p>
   The <code>marker-label</code> directive <strong>was</strong> used to create a marker with a label on an existing map as a child of the marker element / directive.
-  This directive has been removed and your should now use <a href="#marker">marker</a> or <a href="#markers">markers</a> options attribute. The label options are now combined all into one options object to handle all marker customizations.
+  This directive has been removed and your should now use <a href="#!/api/marker">marker</a> or <a href="#!/api/markers">markers</a> options attribute. The label options are now combined all into one options object to handle all marker customizations.
 
   It was removed as the code is more maintainable where a MarkerLabel is now decided in the underlying MarkerChild which both Marker and Markers directives ultimately create.
 </p>

--- a/views/directive/marker-label.html
+++ b/views/directive/marker-label.html
@@ -2,7 +2,7 @@
  <span class="label label-danger">OBSOLETE / REMOVED</span>
  <p>
   The <code>marker-label</code> directive <strong>was</strong> used to create a marker with a label on an existing map as a child of the marker element / directive.
-  This directive has been removed and your should now use <a href="#!/api/marker">marker</a> or <a href="#!/api/markers">markers</a> options attribute. The label options are now combined all into one options object to handle all marker customizations.
+  This directive has been removed and your should now use <a ui-sref="api.marker" class="ng-binding" href="#!/api">marker</a> or <a ui-sref="api.markers" class="ng-binding" href="#!/api">markers</a> options attribute. The label options are now combined all into one options object to handle all marker customizations.
 
   It was removed as the code is more maintainable where a MarkerLabel is now decided in the underlying MarkerChild which both Marker and Markers directives ultimately create.
 </p>


### PR DESCRIPTION
While browsing the API, I found that the links on the `marker-label` page to `marker` and `markers` weren't working.
I have added the `ui-sref`-attribute, corrected the `href`-attribute and added the `ng-binding`-class so they are consistent with the links I found on the `markers` page.