### PR TITLE
combined 2 guard clauses

### DIFF
--- a/src/coffee/utils/array-sync.coffee
+++ b/src/coffee/utils/array-sync.coffee
@@ -46,8 +46,7 @@ angular.module('uiGmapgoogle-maps').factory 'uiGmaparray-sync', [
           set_at: (index) ->
             return if isSetFromScope #important to avoid cyclic forever change loop watch to map event change and back
             value = mapArray.getAt(index)
-            return  unless value
-            return  if not value.lng or not value.lat
+            return unless value and value.lng and value.lat
             geojsonArray[index][1] = value.lat()
             geojsonArray[index][0] = value.lng()
 


### PR DESCRIPTION
Two guard clauses have been combined into one. Previously one clause
was checking for the object's existence, the other was checking for
its attributes. Now the same guard clause chains the conditions
together thereby reducing a code line.