### PR TITLE
Fix Issue #1485 - Model-Key comparison

### DIFF
--- a/example/assets/scripts/controllers/issue-1485-doRebuildAll.js
+++ b/example/assets/scripts/controllers/issue-1485-doRebuildAll.js
@@ -1,0 +1,82 @@
+angular.module('testApp', ['uiGmapgoogle-maps'])
+.config(['uiGmapGoogleMapApiProvider', function (GoogleMapApiProvider) {
+  GoogleMapApiProvider.configure({
+        //    key: 'your api key',
+        v: '3.17',
+        libraries: 'weather,geometry,visualization,places'
+    });
+}])
+.controller('TestController', ['$scope','uiGmapGoogleMapApi', function ($scope,GoogleMapApi) {
+
+  $scope.map = {
+		center: {
+			latitude: 33.7550,
+			longitude: -84.3900
+		},
+		zoom: 14,
+		options: {
+			scrollwheel: false,
+			panControl: false,
+			scaleControl: false,
+			draggable: true,
+			doRebuildAll: false,
+			maxZoom: 22,
+			minZoom: 0
+		},
+		clusterOptions: {
+        averageCenter: true,
+        minimumClusterSize: 10,
+        zoomOnClick: true
+		},
+		clusterEvents: {},
+		refresh : false,
+		bounds: {},
+		events: {
+			idle: function() {
+				console.log('idle');
+			}
+		},
+	};
+
+  $scope.addMarker = function(){
+    var marker = buildMarker();
+    $scope.markers.push(marker);
+  }
+
+  buildMarker = function(){
+    var randomLat = getRandomInt(336550, 338550) / 10000;
+    var randomLng =  getRandomInt(-843900,-843700) / 10000;
+    return {
+      id: nextId(),
+      coords: {
+        latitude: randomLat,
+        longitude: randomLng,
+      },
+      options: $scope.markerOptions
+    }
+  }
+
+	nextId = function() {
+	  return $scope.markers.length + 1;
+	}
+
+	getRandomInt = function(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+
+	$scope.markers = [];
+
+  GoogleMapApi.then(function(maps) {
+    console.log('start');
+    $scope.maps = maps;
+    $scope.markerOptions = {
+      animation: $scope.maps.Animation.DROP,
+      visible: true
+    }
+    $scope.addMarker();
+    $scope.addMarker();
+    $scope.addMarker();
+    $scope.doRebuildAll = false;
+  });
+
+}]);

--- a/example/issue-1485-doRebuildAll.html
+++ b/example/issue-1485-doRebuildAll.html
@@ -15,7 +15,7 @@
 <body ng-controller="TestController">
     {{sites}}
     <ui-gmap-google-map class="col-sm-12 pad-none" center="map.center" zoom="map.zoom" style="min-height: 600px" draggable="true">
-      <ui-gmap-markers fit="true" doRebuildAll="doRebuildAll" models="markers" coords="'coords'" options="'options'" clusteroptions="map.clusterOptions">
+      <ui-gmap-markers fit="true" deepComparison="true" doRebuildAll="doRebuildAll" models="markers" coords="'coords'" options="'options'" clusteroptions="map.clusterOptions">
       </ui-gmap-markers>
     </ui-gmap-google-map>
 

--- a/example/issue-1485-doRebuildAll.html
+++ b/example/issue-1485-doRebuildAll.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html ng-app="testApp">
+
+<head>
+    <script src="http://maps.googleapis.com/maps/api/js?libraries=visualization&language=en&v=3.13"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.3/angular.min.js"></script>
+    <script src="../website_libs/dev_deps.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.min.js" type="text/javascript"></script>
+    <script src="http://cdn.rawgit.com/nmccready/angular-simple-logger/0.0.1/dist/index.js"></script>
+    <script src="../dist/angular-google-maps.js"></script>
+
+    <link href="assets/stylesheets/example.css" rel="stylesheet" type="text/css">
+</head>
+
+<body ng-controller="TestController">
+    {{sites}}
+    <ui-gmap-google-map class="col-sm-12 pad-none" center="map.center" zoom="map.zoom" style="min-height: 600px" draggable="true">
+      <ui-gmap-markers fit="true" doRebuildAll="doRebuildAll" models="markers" coords="'coords'" options="'options'" clusteroptions="map.clusterOptions">
+      </ui-gmap-markers>
+    </ui-gmap-google-map>
+
+    <button ng-click="addMarker()">Add Marker</button>
+</body>
+<script src="assets/scripts/controllers/issue-1485-doRebuildAll.js"></script>
+</html>

--- a/spec/coffee/directives/api/utils/model-key.spec.coffee
+++ b/spec/coffee/directives/api/utils/model-key.spec.coffee
@@ -25,6 +25,7 @@ describe 'ModelKey Tests', ->
       @model6 = {options: {animation: 2, visible: false}, coords: {latitude: 41, longitude: -27}}
       @subject.interface.scopeKeys = ['coords','options']
       delete @scope.coords
+      delete @scope.options
 
     it 'throws with no scope', ->
       expect(@subject.modelKeyComparison).toThrow('No scope set!')

--- a/spec/coffee/directives/api/utils/model-key.spec.coffee
+++ b/spec/coffee/directives/api/utils/model-key.spec.coffee
@@ -20,7 +20,10 @@ describe 'ModelKey Tests', ->
       @model1 = {coords: {latitude: 41, longitude: -27}}
       @model2 = {coords: {latitude: 40, longitude: -27}}
       @model3 = {coords: { type: 'Point', coordinates: [ -27, 40 ] }}
-      @subject.interface.scopeKeys = ['coords']
+      @model4 = {options: {animation: 2, visible: true}, coords: {latitude: 41, longitude: -27}}
+      @model5 = {options: {animation: 2, visible: true}, coords: {latitude: 41, longitude: -27}}
+      @model6 = {options: {animation: 2, visible: false}, coords: {latitude: 41, longitude: -27}}
+      @subject.interface.scopeKeys = ['coords','options']
       delete @scope.coords
 
     it 'throws with no scope', ->
@@ -40,6 +43,17 @@ describe 'ModelKey Tests', ->
       @scope.coords = 'coords'
       expect(@subject.modelKeyComparison(@model2, @model3))
       .toEqual(true)
+
+    it 'model4 to model5 with options is same by values', ->
+      @scope.coords = 'coords'
+      @scope.options = 'options'
+      expect(@subject.modelKeyComparison(@model4, @model5))
+      .toEqual(true)
+    it 'model4 to model6 with different options is diff', ->
+      @scope.coords = 'coords'
+      @scope.options = 'options'
+      expect(@subject.modelKeyComparison(@model4, @model6))
+      .toEqual(false)
 
   it 'should properly set id key', ->
     expect(@subject.idKey).toEqual(undefined)

--- a/spec/coffee/directives/api/utils/model-key.spec.coffee
+++ b/spec/coffee/directives/api/utils/model-key.spec.coffee
@@ -26,6 +26,7 @@ describe 'ModelKey Tests', ->
       @subject.interface.scopeKeys = ['coords','options']
       delete @scope.coords
       delete @scope.options
+      delete @scope.deepComparison
 
     it 'throws with no scope', ->
       expect(@subject.modelKeyComparison).toThrow('No scope set!')
@@ -45,12 +46,27 @@ describe 'ModelKey Tests', ->
       expect(@subject.modelKeyComparison(@model2, @model3))
       .toEqual(true)
 
-    it 'model4 to model5 with options is same by values', ->
+    it 'model4 to model5 with options is same by values with deepComparison', ->
+      @scope.coords = 'coords'
+      @scope.options = 'options'
+      @scope.deepComparison = true
+      expect(@subject.modelKeyComparison(@model4, @model5))
+      .toEqual(true)
+
+    it 'model4 to model5 with options is diff without deepComparison', ->
       @scope.coords = 'coords'
       @scope.options = 'options'
       expect(@subject.modelKeyComparison(@model4, @model5))
-      .toEqual(true)
-    it 'model4 to model6 with different options is diff', ->
+      .toEqual(false)
+
+    it 'model4 to model6 with different options is diff with deepComparison', ->
+      @scope.coords = 'coords'
+      @scope.options = 'options'
+      @scope.deepComparison = true
+      expect(@subject.modelKeyComparison(@model4, @model6))
+      .toEqual(false)
+
+    it 'model4 to model6 with different options is diff without deepComparison', ->
       @scope.coords = 'coords'
       @scope.options = 'options'
       expect(@subject.modelKeyComparison(@model4, @model6))

--- a/src/coffee/directives/api/markers.coffee
+++ b/src/coffee/directives/api/markers.coffee
@@ -15,6 +15,7 @@ angular.module("uiGmapgoogle-maps.directives.api")
           type: '=?type' # cluster, spider, default undefined - normal
           typeOptions: '=?typeoptions'
           typeEvents: '=?typeevents'
+          deepComparison: '=?deepcomparison'
 
         $log.info @
 

--- a/src/coffee/directives/api/models/parent/markers-parent-model.coffee
+++ b/src/coffee/directives/api/models/parent/markers-parent-model.coffee
@@ -49,7 +49,6 @@ angular.module("uiGmapgoogle-maps.directives.api.models.parent")
             @watch 'typeEvents', @scope
             @watch 'fit', @scope
             @watch 'idKey', @scope
-            @watch 'deepComparison', @scope
 
             @gManager = undefined
             @createAllNew(@scope)

--- a/src/coffee/directives/api/models/parent/markers-parent-model.coffee
+++ b/src/coffee/directives/api/models/parent/markers-parent-model.coffee
@@ -49,6 +49,7 @@ angular.module("uiGmapgoogle-maps.directives.api.models.parent")
             @watch 'typeEvents', @scope
             @watch 'fit', @scope
             @watch 'idKey', @scope
+            @watch 'deepComparison', @scope
 
             @gManager = undefined
             @createAllNew(@scope)

--- a/src/coffee/directives/api/plural.coffee
+++ b/src/coffee/directives/api/plural.coffee
@@ -35,6 +35,7 @@ angular.module('uiGmapgoogle-maps.directives.api')
       chunk: '=chunk' #false to disable chunking, otherwise a number to define chunk size
       cleanchunk: '=cleanchunk' #false to disable chunking, otherwise a number to define chunk size
       control: '=control'
+      deepComparison: '=deepcomparison' #true to deep compare attributes on model for determining uniqueness.
 
   link: (scope, parent) ->
     _initControl(scope, parent)

--- a/src/coffee/directives/api/utils/model-key.coffee
+++ b/src/coffee/directives/api/utils/model-key.coffee
@@ -35,8 +35,12 @@ angular.module('uiGmapgoogle-maps.directives.api.utils')
           return isEqual unless isEqual
         #compare the rest of the properties that are being watched by scope
         without = _.without(@interface.scopeKeys, 'coords')
+        console.log("Scope.deepcomparison = " + scope.deepComparison)
+
         isEqual = _.every without, (k) =>
-          _.isEqual(@scopeOrModelVal(scope[k], scope, model1), @scopeOrModelVal(scope[k], scope, model2))
+          m1 = @scopeOrModelVal(scope[k], scope, model1)
+          m2 = @scopeOrModelVal(scope[k], scope, model2)
+          if scope.deepComparison then _.isEqual(m1, m2) else m1 == m2
         isEqual
 
 

--- a/src/coffee/directives/api/utils/model-key.coffee
+++ b/src/coffee/directives/api/utils/model-key.coffee
@@ -35,7 +35,6 @@ angular.module('uiGmapgoogle-maps.directives.api.utils')
           return isEqual unless isEqual
         #compare the rest of the properties that are being watched by scope
         without = _.without(@interface.scopeKeys, 'coords')
-        console.log("Scope.deepcomparison = " + scope.deepComparison)
 
         isEqual = _.every without, (k) =>
           m1 = @scopeOrModelVal(scope[k], scope, model1)

--- a/src/coffee/directives/api/utils/model-key.coffee
+++ b/src/coffee/directives/api/utils/model-key.coffee
@@ -36,7 +36,7 @@ angular.module('uiGmapgoogle-maps.directives.api.utils')
         #compare the rest of the properties that are being watched by scope
         without = _.without(@interface.scopeKeys, 'coords')
         isEqual = _.every without, (k) =>
-          @scopeOrModelVal(scope[k], scope, model1) == @scopeOrModelVal(scope[k], scope, model2)
+          _.isEqual(@scopeOrModelVal(scope[k], scope, model1), @scopeOrModelVal(scope[k], scope, model2))
         isEqual
 
 


### PR DESCRIPTION
fix(model-key): model-key comparison on objects  

Change model-key to use lodash to compare objects
 - When objects (outside of coords) are compared via ===, the comparison always returns falls, even if objects are same.  Thus, with a false comparison, all markers get marked as needing update, negating doRebuildAll=false.  This fixes false negative on comparison.
 - Add simple examples page with examples controller for issue #1485.
 - Update model-key spec to include a non-coord comparison on models

Closes #1485