### PR TITLE
Fix misspelled data-target

### DIFF
--- a/views/faq.html
+++ b/views/faq.html
@@ -139,10 +139,21 @@ If only one window at a time is needed, then use 'window' and change out the bin
 </p>
 <div hljs>
 	<ui-gmap-google-map center="map.center" zoom="map.zoom">
-		<ui-gmap-window show="map.window.show" coords="map.window.model" options="map.window.options" closeclick="map.window.closeClick()">
+		<ui-gmap-window 
+			show="map.window.show"
+			coords="map.window.model" 
+			options="map.window.options"
+			closeclick="map.window.closeClick()">
+			
 			<div ng-non-bindable>test</div>
+		
 		</ui-gmap-window>
-		<ui-gmap-markers idkey="'bid'" models="map.markers" coords="'self'" docluster="false" fit="'true'" icon="'icon'" events="map.markersEvents" options="'options'"></ui-gmap-markers>
+		
+		<ui-gmap-markers
+			idkey="'bid'" models="map.markers" coords="'self'" 
+			docluster="false" fit="'true'" icon="'icon'" 
+			events="map.markersEvents" options="'options'">
+		</ui-gmap-markers>
 	</ui-gmap-google-map>
 </div>
 

--- a/views/faq.html
+++ b/views/faq.html
@@ -16,7 +16,7 @@
 <p>It is possible to access the map instance using the <code>tilesloaded</code> event:</p>
 
 <ul class="nav nav-tabs">
-    <li class="active"><a href="" data-target="#faq-map-instance-tab-html" data-toggle="tab">HTML</a></li>
+    <li class="active"><a href="" data-target="#faq-map-instance-tab-html-js" data-toggle="tab">HTML</a></li>
     <li><a href="" data-target="#faq-map-instance-tab-script" data-toggle="tab">Script</a></li>
 </ul>
 
@@ -27,15 +27,15 @@
         </div>
     </div>
     <div id="faq-map-instance-tab-script" class="tab-pane">
-        <div hljs>
+        <div hljs hljs-language='javascript'>
             $scope.map = {
-            events: {
-            tilesloaded: function (map) {
-            $scope.$apply(function () {
-            $log.info('this is the map instance', map);
-            });
-            }
-            }
+				events: {
+					tilesloaded: function (map) {
+						$scope.$apply(function () {
+							$log.info('this is the map instance', map);
+						});
+					}
+				}
             }
         </div>
     </div>
@@ -62,10 +62,10 @@
         <p>Let's assume we include the map in an <code>ng-view</code> block:</p>
 
         <div hljs>
-            $scope.$on('$viewContentLoaded', function () {
-            var mapHeight = 500; // or any other calculated value
-            $("#my-map .angular-google-map-container").height(mapHeight);
-            });
+			$scope.$on('$viewContentLoaded', function () {
+				var mapHeight = 500; // or any other calculated value
+				$("#my-map .angular-google-map-container").height(mapHeight);
+			});
         </div>
     </div>
     <div id="faq-map-height-tab-html-css" class="tab-pane">


### PR DESCRIPTION
Should fix unable to switch back the html tab on section `How do I access the map instance?` 

Added some code formating