### PR TITLE
fix(build): webpack-dev-server is a peer dependency of grunt-webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "phantomjs-polyfill": "0.0.1",
     "require-directory": "2.1.1",
     "webpack": "^1.9.10",
+    "webpack-dev-server": "^1.14.1",
     "yargs": "3.32.0"
   },
   "dependencies": {


### PR DESCRIPTION
fixes failure of grunt-webpack: Cannot find module 'webpack-dev-server' when running grunt in project