### PR TITLE
Control randomization of callback function name in script loader with a new option

### DIFF
--- a/spec/coffee/providers/google-map-api-provider.spec.coffee
+++ b/spec/coffee/providers/google-map-api-provider.spec.coffee
@@ -25,6 +25,14 @@ describe 'uiGmapGoogleMapApiProvider', ->
     lastScriptIndex = document.getElementsByTagName('script').length - 1
     expect(document.getElementsByTagName('script')[lastScriptIndex].src).toContain('http://maps.google.cn/maps/api/js')
 
+  describe 'options', ->
+    it 'does not randomize the callback name when randomizeCallbackName is false', ->
+      options = { randomizeCallbackName: false, v: '3.17', libraries: '', language: 'en' }
+      mapScriptLoader.load(options)
+      lastScriptIndex = document.getElementsByTagName('script').length - 1
+      lastScriptSrc = document.getElementsByTagName('script')[lastScriptIndex].src
+      expect(_.endsWith lastScriptSrc, 'callback=onGoogleMapsReady').toBe true
+
   describe 'on Cordova devices', ->
     beforeAll ->
       window.navigator.connection = {}

--- a/src/coffee/providers/map-loader.coffee
+++ b/src/coffee/providers/map-loader.coffee
@@ -46,9 +46,12 @@ angular.module('uiGmapgoogle-maps.providers')
           deferred.resolve window.google.maps
           return deferred.promise
 
-        randomizedFunctionName = options.callback = 'onGoogleMapsReady' + Math.round(Math.random() * 1000)
-        window[randomizedFunctionName] = ->
-          window[randomizedFunctionName] = null
+        options.callback = 'onGoogleMapsReady'
+        if options.randomizeCallbackName
+          options.callback += Math.round(Math.random() * 1000)
+        callbackFunctionName = options.callback
+        window[callbackFunctionName] = ->
+          window[callbackFunctionName] = null
           deferred.resolve window.google.maps
           return
 
@@ -60,7 +63,7 @@ angular.module('uiGmapgoogle-maps.providers')
           includeScript options
 
         usedConfiguration = options
-        usedConfiguration.randomizedFunctionName = randomizedFunctionName
+        usedConfiguration.callbackFunctionName = callbackFunctionName
 
         # Return the promise
         deferred.promise
@@ -75,7 +78,7 @@ angular.module('uiGmapgoogle-maps.providers')
         else
           # If the API is loaded but the original configuration's callback has
           # not been executed then do so
-          window[config.randomizedFunctionName]() if window[config.randomizedFunctionName]
+          window[config.callbackFunctionName]() if window[config.callbackFunctionName]
 ])
 #holy hool!!, any time your passing a dependency to a 'provider' you must append the Provider text to the service
 # name.. makes no sense and this is not documented well
@@ -94,6 +97,7 @@ angular.module('uiGmapgoogle-maps.providers')
       libraries: ''
       language: 'en'
       preventLoad: false
+      randomizeCallbackName: true
 
     # A function that lets us configure options of the service
     @configure = (options) ->


### PR DESCRIPTION
Motivation: I have a single page app that uses angular-google-maps and I attempted to use the Application Cache to cache some assets. I could not cache the main Google Maps script because the script loader randomizes the callback references in the call to fetch this script, i.e. the full URL for the fetched script changes every time. 

This PR adds an option that determines whether or not to randomize the name of the callback. It is true by default. When it is false, the full URL for the Google Maps script is static and can be cached. 