### PR TITLE
Fix incorrect lodash paths in examples

### DIFF
--- a/example/issue_1466_map_flicker.html
+++ b/example/issue_1466_map_flicker.html
@@ -12,7 +12,7 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.2.15/angular-ui-router.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/angular-filter/0.4.7/angular-filter.js"></script>
   <script src="../bower_components/angular-simple-logger/dist/angular-simple-logger.js"></script>
-  <script src='../bower_components/lodash/lodash.min.js'></script>
+  <script src='../bower_components/lodash/lodash.js'></script>
   <script src='../dist/angular-google-maps_dev_mapped.js'></script>
 
 

--- a/example/issue_1542_cartodb.html
+++ b/example/issue_1542_cartodb.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <script src='../bower_components/lodash/lodash.min.js'></script>
+  <script src='../bower_components/lodash/lodash.js'></script>
   <script src="../bower_components/angular/angular.js"></script>
   <script src="../bower_components/angular-simple-logger/dist/angular-simple-logger.js"></script>
   <script src='../dist/angular-google-maps_dev_mapped.js'></script>

--- a/example/issue_1574_marker_dupes.html
+++ b/example/issue_1574_marker_dupes.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <script src='../bower_components/lodash/lodash.min.js'></script>
+  <script src='../bower_components/lodash/lodash.js'></script>
   <script src="../bower_components/angular/angular.js"></script>
   <script src="../bower_components/angular-simple-logger/dist/angular-simple-logger.js"></script>
   <script src='../dist/angular-google-maps_dev_mapped.js'></script>


### PR DESCRIPTION
`lodash.min.js` no longer exists in the root lodash folder resolved by bower which was breaking any examples that referenced this file. This fix replaces these with the unminified version, as this is guaranteed to exist and keeps things consistent with the other (unminified) dependencies.

Happy to change this to use the file in `dist/lodash.min.js` if it's required, or switch to cloudflare like some of the other examples do.

Cheers