### PR TITLE
Removing usless parent div in inline template from control

### DIFF
--- a/src/coffee/directives/api/control.coffee
+++ b/src/coffee/directives/api/control.coffee
@@ -44,7 +44,7 @@ angular.module("uiGmapgoogle-maps.directives.api")
 
                 controlDiv.append transcludeEl
 
-                pushControl(map, controlDiv, index)
+                pushControl(map, controlDiv.children(), index)
 
             else
               $http.get(scope.template, { cache: $templateCache })


### PR DESCRIPTION
The current inline map-control has a usless div that can affect the style of the map-control.