### PR TITLE
$http's deprecated custom callback methods

### DIFF
--- a/src/coffee/directives/api/control.coffee
+++ b/src/coffee/directives/api/control.coffee
@@ -44,7 +44,7 @@ angular.module("uiGmapgoogle-maps.directives.api")
               $http.get(scope.template, { cache: $templateCache })
               .then (template) =>
                 templateScope = scope.$new()
-                controlDiv.append template
+                controlDiv.append template.data
 
                 # if a controller is defined on the directive then add it to the template
                 if angular.isDefined scope.controller

--- a/src/coffee/directives/api/control.coffee
+++ b/src/coffee/directives/api/control.coffee
@@ -42,7 +42,7 @@ angular.module("uiGmapgoogle-maps.directives.api")
 
             else
               $http.get(scope.template, { cache: $templateCache })
-              .success (template) =>
+              .then (template) =>
                 templateScope = scope.$new()
                 controlDiv.append template
 
@@ -54,7 +54,7 @@ angular.module("uiGmapgoogle-maps.directives.api")
                 # use children() rather than content() as the former seems to trim the content
                 control = $compile(controlDiv.children())(templateScope)
 
-              .error (error) =>
+              .catch (error) =>
                 @$log.error 'mapControl: template could not be found'
               .then =>
                 pushControl(map, control, index)

--- a/src/coffee/directives/search-box.coffee
+++ b/src/coffee/directives/search-box.coffee
@@ -51,6 +51,6 @@ angular.module('uiGmapgoogle-maps')
                 if not maps.ControlPosition[ctrlPosition]
                     @$log.error 'searchBox: invalid position property'
                     return
-                new SearchBoxParentModel(scope, element, attrs, map, ctrlPosition, $compile(template)(scope))
+                new SearchBoxParentModel(scope, element, attrs, map, ctrlPosition, $compile(template.data)(scope))
     new SearchBox()
 ]

--- a/src/coffee/directives/search-box.coffee
+++ b/src/coffee/directives/search-box.coffee
@@ -42,7 +42,7 @@ angular.module('uiGmapgoogle-maps')
             $templateCache.put 'uigmap-searchbox-default.tpl.html', '<input type="text">'
             scope.template = 'uigmap-searchbox-default.tpl.html'
           $http.get(scope.template, { cache: $templateCache })
-            .success (template) =>
+            .then (template) =>
               if angular.isUndefined scope.events
                 @$log.error 'searchBox: the events property is required'
                 return


### PR DESCRIPTION
This PR fixes [#1989](https://github.com/angular-ui/angular-google-maps/issues/1989).

The `.success` and `.error` methods are deprecated and have been removed from [AngularJS 1.6](https://github.com/angular/angular.js/commit/b54a39e2029005e0572fbd2ac0e8f6a4e5d69014). Use the standard `.then` and `.catch` method instead.

Before:
```js
$http(...).
success(function onSuccess(data, status, headers, config) {
  // Handle success
  ...
}).
error(function onError(data, status, headers, config) {
  // Handle error
  ...
});
```

After:
```js
$http(...).
  then(function onSuccess(response) {
    // Handle success
    var data = response.data;
    var status = response.status;
    var statusText = response.statusText;
    var headers = response.headers;
    var config = response.config;
    ...
  }, function onError(response) {
    // Handle error
    var data = response.data;
    var status = response.status;
    var statusText = response.statusText;
    var headers = response.headers;
    var config = response.config;
    ...
  });

// or

$http(...).
  then(function onSuccess(response) {
    // Handle success
    var data = response.data;
    var status = response.status;
    var statusText = response.statusText;
    var headers = response.headers;
    var config = response.config;
    ...
  }).
  catch(function onError(response) {
    // Handle error
    var data = response.data;
    var status = response.status;
    var statusText = response.statusText;
    var headers = response.headers;
    var config = response.config;
    ...
  });
```